### PR TITLE
Set m_eventHandlers to use weak object pointers instead of SharedPtrs.

### DIFF
--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -331,10 +331,10 @@ bool FRenderStreamModule::PopulateStreamPool()
 
         // Broadcast streams changed event
         for (TWeakObjectPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
-			if (eventHandler.IsValid())
-			{
-				eventHandler->onStreamsChanged(streamInfoArray);
-			}
+        {
+            if (eventHandler.IsValid())
+                eventHandler->onStreamsChanged(streamInfoArray);
+        }
 
         return true;
     }
@@ -481,8 +481,10 @@ void FRenderStreamModule::OnPostLoadMapWithWorld(UWorld* InWorld)
         }
 
         for (TWeakObjectPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
-			if(eventHandler.IsValid())
-				eventHandler->onStreamsChanged(streamInfoArray);
+        {
+            if (eventHandler.IsValid())
+                eventHandler->onStreamsChanged(streamInfoArray);
+        }
     }
 
     EnableStats();

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -330,8 +330,11 @@ bool FRenderStreamModule::PopulateStreamPool()
         }
 
         // Broadcast streams changed event
-        for (TSharedPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
-            eventHandler->onStreamsChanged(streamInfoArray);
+        for (TWeakObjectPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
+			if (eventHandler.IsValid())
+			{
+				eventHandler->onStreamsChanged(streamInfoArray);
+			}
 
         return true;
     }
@@ -456,14 +459,14 @@ void FRenderStreamModule::OnPostLoadMapWithWorld(UWorld* InWorld)
     // Find all event handlers
     if (InWorld)
     {
-        m_eventHandlers = TArray<TSharedPtr<ARenderStreamEventHandler>>();
+        m_eventHandlers.Empty();
         TArray<AActor*> FoundActors;
         UGameplayStatics::GetAllActorsOfClass(InWorld, ARenderStreamEventHandler::StaticClass(), FoundActors);
 
         for (AActor* Actor : FoundActors)
         {
             if (ARenderStreamEventHandler* EventHandler = Cast<ARenderStreamEventHandler>(Actor))
-                m_eventHandlers.Add(MakeShareable(EventHandler));
+                m_eventHandlers.Add(EventHandler);
         }
     }
 
@@ -477,8 +480,9 @@ void FRenderStreamModule::OnPostLoadMapWithWorld(UWorld* InWorld)
                 streamInfoArray.Push({ FString(stream->Channel()), FString(stream->Name()) });
         }
 
-        for (TSharedPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
-            eventHandler->onStreamsChanged(streamInfoArray);
+        for (TWeakObjectPtr<ARenderStreamEventHandler> eventHandler : m_eventHandlers)
+			if(eventHandler.IsValid())
+				eventHandler->onStreamsChanged(streamInfoArray);
     }
 
     EnableStats();

--- a/Source/RenderStream/Private/RenderStream.h
+++ b/Source/RenderStream/Private/RenderStream.h
@@ -40,7 +40,7 @@ protected:
 
     void EnableStats() const;
 
-    TArray<TSharedPtr<ARenderStreamEventHandler>> m_eventHandlers;
+    TArray<TWeakObjectPtr<ARenderStreamEventHandler>> m_eventHandlers;
 
 public:
     static EUnit distanceUnit();


### PR DESCRIPTION
Non-standard use of TSharedPtr. Causes crashes due to UObject lifetime being managed by other things.