### PR TITLE
R1.29 ue4.27 depth compression

### DIFF
--- a/Shaders/Private/copy.usf
+++ b/Shaders/Private/copy.usf
@@ -11,3 +11,12 @@ void RSCopyPS(
 	OutColor = RSResizeCopyUB.Texture.Sample(RSResizeCopyUB.Sampler, ScaledUV);
 	OutColor.a = 1.f - OutColor.a;
 }
+
+void RSDepthCopyPS(
+	float4 InPosition : SV_POSITION,
+	float2 InUV : TEXCOORD0,
+	out float4 OutColor : SV_Target0)
+{
+	float2 ScaledUV = InUV; // * RSResizeCopyUB.UVScale;
+	OutColor = RSResizeCopyUB.Texture.Sample(RSResizeCopyUB.Sampler, ScaledUV).r;
+}

--- a/Shaders/Private/copy.usf
+++ b/Shaders/Private/copy.usf
@@ -18,5 +18,6 @@ void RSDepthCopyPS(
 	out float4 OutColor : SV_Target0)
 {
 	float2 ScaledUV = InUV; // * RSResizeCopyUB.UVScale;
-	OutColor = RSResizeCopyUB.Texture.Sample(RSResizeCopyUB.Sampler, ScaledUV).r;
+	float z = RSResizeCopyUB.Texture.Sample(RSResizeCopyUB.Sampler, ScaledUV).r;
+    OutColor = 1.f / z; // convert from device to scene z here.
 }

--- a/Source/RenderStream/Private/FrameStream.cpp
+++ b/Source/RenderStream/Private/FrameStream.cpp
@@ -4,19 +4,20 @@
 #include "RSUCHelpers.inl"
 
 FFrameStream::FFrameStream()
-    : m_streamName(""), m_bufTexture(nullptr), m_handle(0) {}
+    : m_streamName(""), m_bufTextures{ nullptr, nullptr }, m_handle(0) {}
 
 FFrameStream::~FFrameStream()
 {
 }
 
-void FFrameStream::SendFrame_RenderingThread(FRHICommandListImmediate& RHICmdList, RenderStreamLink::CameraResponseData& FrameData, FRHITexture2D* SourceTexture, const FIntRect& ViewportRect)
+void FFrameStream::SendFrame_RenderingThread(FRHICommandListImmediate& RHICmdList, RenderStreamLink::CameraResponseData& FrameData, RenderStreamLink::Textures InTextures, const FIntRect& ViewportRect)
 {
+    auto SourceTexture = InTextures.Colour;
     float ULeft = (float)ViewportRect.Min.X / (float)SourceTexture->GetSizeX();
     float URight = (float)ViewportRect.Max.X / (float)SourceTexture->GetSizeX();
     float VTop = (float)ViewportRect.Min.Y / (float)SourceTexture->GetSizeY();
     float VBottom = (float)ViewportRect.Max.Y / (float)SourceTexture->GetSizeY();
-    RSUCHelpers::SendFrame(m_handle, m_bufTexture, RHICmdList, FrameData, SourceTexture, SourceTexture->GetSizeXY(), { ULeft, URight }, { VTop, VBottom });
+    RSUCHelpers::SendFrame(m_handle, m_bufTextures, RHICmdList, FrameData, InTextures, SourceTexture->GetSizeXY(), { ULeft, URight }, { VTop, VBottom });
 }
 
 bool FFrameStream::Setup(const FString& name, const FIntPoint& Resolution, const FString& Channel, const RenderStreamLink::ProjectionClipping& Clipping, RenderStreamLink::StreamHandle Handle, RenderStreamLink::RSPixelFormat fmt)
@@ -29,8 +30,10 @@ bool FFrameStream::Setup(const FString& name, const FIntPoint& Resolution, const
     m_clipping = Clipping;
     m_resolution = Resolution;
     m_streamName = name;
-
-    if (!RSUCHelpers::CreateStreamResources(m_bufTexture, m_resolution, fmt))
+    if (!RSUCHelpers::CreateStreamResources(m_bufTextures.Colour, m_resolution, fmt))
+        return false; // helper method logs on failure
+    
+    if (!RSUCHelpers::CreateStreamResources(m_bufTextures.Depth, m_resolution, RenderStreamLink::RSPixelFormat::RS_FMT_RGBA32F))
         return false; // helper method logs on failure
 
     if (m_handle == 0) {

--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -180,12 +180,13 @@ namespace RSUCHelpers
 
         Blit<RSResizeCopy>(RHICmdList, BufTexture.Colour, InTextures.Colour, Point, CropU, CropV, TEXT("RS Blit Colour"));
         
-        Blit<RSResizeCopyDepth>(RHICmdList, BufTexture.Depth, InTextures.Depth, Point, CropU, CropV, TEXT("RS Blit Depth"));
+        if(InTextures.Depth)
+            Blit<RSResizeCopyDepth>(RHICmdList, BufTexture.Depth, InTextures.Depth, Point, CropU, CropV, TEXT("RS Blit Depth"));
         
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS API Block"));
 
         void* colour = BufTexture.Colour->GetNativeResource();
-        void* depth = BufTexture.Depth->GetNativeResource();
+        void* depth = (InTextures.Depth) ? BufTexture.Depth->GetNativeResource() : nullptr;
 
         auto toggle = FHardwareInfo::GetHardwareInfo(NAME_RHI);
         if (toggle == "D3D11")

--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -179,9 +179,9 @@ namespace RSUCHelpers
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Send Frame"));
 
         Blit<RSResizeCopy>(RHICmdList, BufTexture.Colour, InTextures.Colour, Point, CropU, CropV, TEXT("RS Blit Colour"));
-        //if(InTextures.Depth)
-        //    Blit<RSResizeCopyDepth>(RHICmdList, BufTexture.Depth, InTextures.Depth, Point, CropU, CropV, TEXT("RS Blit Depth"));
-
+        
+        Blit<RSResizeCopyDepth>(RHICmdList, BufTexture.Depth, InTextures.Depth, Point, CropU, CropV, TEXT("RS Blit Depth"));
+        
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS API Block"));
 
         void* colour = BufTexture.Colour->GetNativeResource();
@@ -241,7 +241,7 @@ namespace RSUCHelpers
             { DXGI_FORMAT_R32G32B32A32_FLOAT, EPixelFormat::PF_A32B32G32R32F}, // RS_FMT_RGBA16 
             { DXGI_FORMAT_R8G8B8A8_UNORM, EPixelFormat::PF_R8G8B8A8 },         // RS_FMT_RGBA8
             { DXGI_FORMAT_R8G8B8A8_UNORM, EPixelFormat::PF_R8G8B8A8 },         // RS_FMT_RGBX8
-            { DXGI_FORMAT_R32_FLOAT, EPixelFormat::PF_R32_FLOAT}
+            {DXGI_FORMAT_R32_FLOAT, EPixelFormat::PF_R32_FLOAT}
         };
         const auto format = formatMap[rsFormat];
 

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -63,6 +63,8 @@
 #include "Config/IDisplayClusterConfigManager.h"
 #include "Render/Viewport/IDisplayClusterViewportManager.h"
 
+#include "RenderStreamSceneViewExtension.h"
+
 DEFINE_LOG_CATEGORY(LogRenderStream);
 
 #define LOCTEXT_NAMESPACE "FRenderStreamModule"
@@ -197,6 +199,9 @@ void FRenderStreamModule::StartupModule()
     {
         FModuleManager::Get().OnModulesChanged().AddRaw(this, &FRenderStreamModule::OnModulesChanged);
     }
+
+    ViewExtension = FRenderStreamSceneViewExtension::Create();
+
 }
 
 void FRenderStreamModule::ShutdownModule()

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -63,8 +63,6 @@
 #include "Config/IDisplayClusterConfigManager.h"
 #include "Render/Viewport/IDisplayClusterViewportManager.h"
 
-#include "RenderStreamSceneViewExtension.h"
-
 DEFINE_LOG_CATEGORY(LogRenderStream);
 
 #define LOCTEXT_NAMESPACE "FRenderStreamModule"
@@ -199,8 +197,6 @@ void FRenderStreamModule::StartupModule()
     {
         FModuleManager::Get().OnModulesChanged().AddRaw(this, &FRenderStreamModule::OnModulesChanged);
     }
-
-    ViewExtension = FRenderStreamSceneViewExtension::Create();
 
 }
 

--- a/Source/RenderStream/Private/RenderStream.h
+++ b/Source/RenderStream/Private/RenderStream.h
@@ -27,6 +27,8 @@ class FRenderStreamProjectionPolicyFactory;
 class FRenderStreamPostProcessFactory;
 class ARenderStreamEventHandler;
 
+class FRenderStreamSceneViewExtension;
+
 struct FRenderStreamViewportInfo
 {
     TWeakObjectPtr<ACameraActor> Template = nullptr;
@@ -83,5 +85,6 @@ public:
     TSharedPtr<FRenderStreamProjectionPolicyFactory> ProjectionPolicyFactory;
     TSharedPtr<FRenderStreamPostProcessFactory> PostProcessFactory;
     TSharedPtr<FRenderStreamLogOutputDevice, ESPMode::ThreadSafe> m_logDevice = nullptr;
+    TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> ViewExtension = nullptr;
     double m_LastTime = 0;
 };

--- a/Source/RenderStream/Private/RenderStream.h
+++ b/Source/RenderStream/Private/RenderStream.h
@@ -27,8 +27,6 @@ class FRenderStreamProjectionPolicyFactory;
 class FRenderStreamPostProcessFactory;
 class ARenderStreamEventHandler;
 
-class FRenderStreamSceneViewExtension;
-
 struct FRenderStreamViewportInfo
 {
     TWeakObjectPtr<ACameraActor> Template = nullptr;
@@ -85,6 +83,6 @@ public:
     TSharedPtr<FRenderStreamProjectionPolicyFactory> ProjectionPolicyFactory;
     TSharedPtr<FRenderStreamPostProcessFactory> PostProcessFactory;
     TSharedPtr<FRenderStreamLogOutputDevice, ESPMode::ThreadSafe> m_logDevice = nullptr;
-    TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> ViewExtension = nullptr;
+
     double m_LastTime = 0;
 };

--- a/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
+++ b/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
@@ -38,6 +38,8 @@ bool FRenderStreamCapturePostProcess::HandleStartScene(IDisplayClusterViewportMa
 
     Module->LoadSchemas(*GWorld);
 
+    ViewExtension = FRenderStreamSceneViewExtension::Create();
+
     return true;
 }
 void FRenderStreamCapturePostProcess::HandleEndScene(IDisplayClusterViewportManager* InViewportManager) {}
@@ -72,7 +74,7 @@ void FRenderStreamCapturePostProcess::PerformPostProcessViewAfterWarpBlend_Rende
         check(Resources.Num() == 1);
         check(Rects.Num() == 1);
 
-        FRHITexture2D* depth = Module->ViewExtension->getExtractedDepth();
+        FRHITexture2D* depth = ViewExtension->getExtractedDepth();
         RenderStreamLink::Textures textures{Resources[0], depth};
         Stream->SendFrame_RenderingThread(RHICmdList, frameResponse, textures, Rects[0]);
     }

--- a/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
+++ b/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
@@ -10,6 +10,8 @@
 #include "Render/Viewport/IDisplayClusterViewportManager.h"
 #include "Render/Viewport/IDisplayClusterViewportProxy.h"
 
+#include "RenderStreamSceneViewExtension.h"
+
 class UCameraComponent;
 class UWorld;
 class FRenderStreamModule;
@@ -69,7 +71,10 @@ void FRenderStreamCapturePostProcess::PerformPostProcessViewAfterWarpBlend_Rende
         ViewportProxy->GetResourcesWithRects_RenderThread(EDisplayClusterViewportResourceType::OutputFrameTargetableResource, Resources, Rects);
         check(Resources.Num() == 1);
         check(Rects.Num() == 1);
-        Stream->SendFrame_RenderingThread(RHICmdList, frameResponse, Resources[0], Rects[0]);
+
+        FRHITexture2D* depth = Module->ViewExtension->getExtractedDepth();
+        RenderStreamLink::Textures textures{Resources[0], depth};
+        Stream->SendFrame_RenderingThread(RHICmdList, frameResponse, textures, Rects[0]);
     }
 
     // Uncomment this to restore client display

--- a/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
+++ b/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
@@ -74,8 +74,9 @@ void FRenderStreamCapturePostProcess::PerformPostProcessViewAfterWarpBlend_Rende
         check(Resources.Num() == 1);
         check(Rects.Num() == 1);
 
+
         FRHITexture2D* depth = ViewExtension->getExtractedDepth();
-        RenderStreamLink::Textures textures{Resources[0], depth};
+        RenderStreamLink::Textures textures{Resources[0], depth };
         Stream->SendFrame_RenderingThread(RHICmdList, frameResponse, textures, Rects[0]);
     }
 

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -364,7 +364,6 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
         { RenderStreamLink::RS_FMT_RGBA16, EPixelFormat::PF_A16B16G16R16 },
         { RenderStreamLink::RS_FMT_RGBA8, EPixelFormat::PF_R8G8B8A8},
         { RenderStreamLink::RS_FMT_RGBX8, EPixelFormat::PF_R8G8B8A8 },
-        { RenderStreamLink::RS_FMT_R32F, EPixelFormat::PF_R32_FLOAT}
     };
 
     size_t iParam = 0;

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -364,6 +364,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
         { RenderStreamLink::RS_FMT_RGBA16, EPixelFormat::PF_A16B16G16R16 },
         { RenderStreamLink::RS_FMT_RGBA8, EPixelFormat::PF_R8G8B8A8},
         { RenderStreamLink::RS_FMT_RGBX8, EPixelFormat::PF_R8G8B8A8 },
+        { RenderStreamLink::RS_FMT_R32F, EPixelFormat::PF_R32_FLOAT}
     };
 
     size_t iParam = 0;

--- a/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
@@ -29,17 +29,17 @@ TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> FRenderStreamSc
 void FRenderStreamSceneViewExtension::PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily)
 {
     
-    FSceneRenderTargets& SceneContext = FSceneRenderTargets::Get(RHICmdList);
-    FTexture2DRHIRef depthTex = SceneContext.GetSceneDepthTexture();
-    copyToIntermediateBuffer_RenderThread(RHICmdList, depthTex, m_intermediateDepth);
-
-    UE_LOG(LogRenderStreamViewExtension, Verbose, TEXT("Copied SceneDepth texture on PostRenderViewFamily_RenderThread"));
     
 }
 
 void FRenderStreamSceneViewExtension::PostRenderBasePass_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView)
 {
     // Here is where GBuffer info should be extracted
+    FSceneRenderTargets& SceneContext = FSceneRenderTargets::Get(RHICmdList);
+    FTexture2DRHIRef depthTex = SceneContext.GetSceneDepthTexture();
+    copyToIntermediateBuffer_RenderThread(RHICmdList, depthTex, m_intermediateDepth);
+
+    UE_LOG(LogRenderStreamViewExtension, Verbose, TEXT("Copied SceneDepth texture on PostRenderViewFamily_RenderThread"));
 
 }
 

--- a/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
@@ -3,17 +3,25 @@
 #include "RenderStreamSceneViewExtension.h"
 #include "Renderer/Private/PostProcess/SceneRenderTargets.h"
 
+#include "CoreGlobals.h"
+
 DEFINE_LOG_CATEGORY(LogRenderStreamViewExtension);
 
 FRenderStreamSceneViewExtension::FRenderStreamSceneViewExtension(const FAutoRegister& AutoRegister) : FSceneViewExtensionBase(AutoRegister)
 {
+    m_depthEnabled = false;
+    check(GConfig->GetBool(TEXT("/Script/RenderStream.Experimental"), TEXT("enableDepth"), m_depthEnabled, GEngineIni));
+
     IsActiveThisFrameFunctions.Empty();
     FSceneViewExtensionIsActiveFunctor IsActiveFunctor;
-    IsActiveFunctor.IsActiveFunction = [](const ISceneViewExtension* SceneViewExtension, const FSceneViewExtensionContext& Context)
+    IsActiveFunctor.IsActiveFunction = [=](const ISceneViewExtension* SceneViewExtension, const FSceneViewExtensionContext& Context)
     {
-        return TOptional<bool>(true);
+        return TOptional<bool>(m_depthEnabled);
     };
     IsActiveThisFrameFunctions.Add(IsActiveFunctor);
+
+
+   
 }
 
 FRenderStreamSceneViewExtension::~FRenderStreamSceneViewExtension()
@@ -88,5 +96,5 @@ FTexture2DRHIRef FRenderStreamSceneViewExtension::getExtractedDepth()
 
 bool FRenderStreamSceneViewExtension::IsActiveThisFrame_Internal(const FSceneViewExtensionContext& Context) const
 {
-    return true;
+    return m_depthEnabled;
 }

--- a/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
@@ -1,0 +1,86 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "RenderStreamSceneViewExtension.h"
+#include "Renderer/Private/PostProcess/SceneRenderTargets.h"
+
+DEFINE_LOG_CATEGORY(LogRenderStreamViewExtension);
+
+FRenderStreamSceneViewExtension::FRenderStreamSceneViewExtension(const FAutoRegister& AutoRegister) : FSceneViewExtensionBase(AutoRegister)
+{
+    IsActiveThisFrameFunctions.Empty();
+    FSceneViewExtensionIsActiveFunctor IsActiveFunctor;
+    IsActiveFunctor.IsActiveFunction = [](const ISceneViewExtension* SceneViewExtension, const FSceneViewExtensionContext& Context)
+    {
+        return TOptional<bool>(true);
+    };
+    IsActiveThisFrameFunctions.Add(IsActiveFunctor);
+}
+
+FRenderStreamSceneViewExtension::~FRenderStreamSceneViewExtension()
+{
+}
+
+TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> FRenderStreamSceneViewExtension::Create()
+{
+    return FSceneViewExtensions::NewExtension<FRenderStreamSceneViewExtension>();
+}
+
+void FRenderStreamSceneViewExtension::PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily)
+{
+    
+    FSceneRenderTargets& SceneContext = FSceneRenderTargets::Get(RHICmdList);
+    FTexture2DRHIRef depthTex = SceneContext.GetSceneDepthTexture();
+    copyToIntermediateBuffer_RenderThread(RHICmdList, depthTex, m_intermediateDepth);
+
+    UE_LOG(LogRenderStreamViewExtension, Verbose, TEXT("Copied SceneDepth texture on PostRenderViewFamily_RenderThread"));
+    
+}
+
+void FRenderStreamSceneViewExtension::PostRenderBasePass_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView)
+{
+    // Here is where GBuffer info should be extracted
+
+}
+
+/*static*/ void FRenderStreamSceneViewExtension::copyToIntermediateBuffer_RenderThread(FRHICommandListImmediate& RHICmdList, FTexture2DRHIRef& Src, FTexture2DRHIRef& Dst)
+{
+    if (!Dst.IsValid() || Dst->GetSizeXY() != Src->GetSizeXY())
+    {
+        FRHIResourceCreateInfo createInfo;
+        Dst = RHICreateTexture2D(Src->GetSizeX(),
+            Src->GetSizeY(),
+            Src->GetFormat(),
+            Src->GetNumMips(),
+            Src->GetNumSamples(),
+            Src->GetFlags(),
+            createInfo);
+        FString name(Src->GetName().ToString() + " intermediate");
+        Dst->SetName(FName(name));
+        UE_LOG(LogRenderStreamViewExtension, Verbose, TEXT("Intermediate texture created for %s"), *Src->GetName().ToString());
+    }
+
+    if (RHICmdList.IsOutsideRenderPass())
+    {
+        FRHICopyTextureInfo copyInfo;
+        uint32 sizeX = Src->GetSizeX();
+        uint32 sizeY = Src->GetSizeY();
+        copyInfo.SourcePosition = FIntVector(0, 0, 0);
+        copyInfo.DestPosition = FIntVector(0, 0, 0);
+        copyInfo.Size = FIntVector(sizeX, sizeY, 1);
+        RHICmdList.CopyTexture(Src, Dst, copyInfo);
+    }
+    else
+    {
+        UE_LOG(LogRenderStreamViewExtension, Verbose, TEXT("Copying %s into %s"), *Src->GetName().ToString(), *Dst->GetName().ToString());
+        FResolveParams params;
+        uint32 sizeX = Src->GetSizeX();
+        uint32 sizeY = Src->GetSizeY();
+        params.Rect = FResolveRect(FIntRect(FIntPoint(0, 0), FIntPoint(sizeX, sizeY)));
+        params.DestRect = FResolveRect(FIntRect(FIntPoint(0, 0), FIntPoint(sizeX, sizeY)));
+        RHICmdList.CopyToResolveTarget(Src, Dst, params);
+    }
+}
+FTexture2DRHIRef FRenderStreamSceneViewExtension::getExtractedDepth()
+{
+    return m_intermediateDepth.IsValid() ? m_intermediateDepth : nullptr;
+}

--- a/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneViewExtension.cpp
@@ -22,7 +22,8 @@ FRenderStreamSceneViewExtension::~FRenderStreamSceneViewExtension()
 
 TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> FRenderStreamSceneViewExtension::Create()
 {
-    return FSceneViewExtensions::NewExtension<FRenderStreamSceneViewExtension>();
+    auto ext =  FSceneViewExtensions::NewExtension<FRenderStreamSceneViewExtension>();
+    return ext;
 }
 
 void FRenderStreamSceneViewExtension::PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily)
@@ -83,4 +84,9 @@ void FRenderStreamSceneViewExtension::PostRenderBasePass_RenderThread(FRHIComman
 FTexture2DRHIRef FRenderStreamSceneViewExtension::getExtractedDepth()
 {
     return m_intermediateDepth.IsValid() ? m_intermediateDepth : nullptr;
+}
+
+bool FRenderStreamSceneViewExtension::IsActiveThisFrame_Internal(const FSceneViewExtensionContext& Context) const
+{
+    return true;
 }

--- a/Source/RenderStream/Public/FrameStream.h
+++ b/Source/RenderStream/Public/FrameStream.h
@@ -15,7 +15,7 @@ public:
 
     void SendFrame_RenderingThread(FRHICommandListImmediate & RHICmdList, 
                                    RenderStreamLink::CameraResponseData& FrameData,
-                                   FRHITexture2D* InSourceTexture,
+                                   RenderStreamLink::Textures InTextures,
                                    const FIntRect& ViewportRect);
 
     bool Setup(const FString& Name, const FIntPoint& Resolution, const FString& Channel, const RenderStreamLink::ProjectionClipping& Clipping, RenderStreamLink::StreamHandle Handle, RenderStreamLink::RSPixelFormat Fmt);
@@ -30,7 +30,7 @@ private:
     FString m_streamName;
     FString m_channel;
     RenderStreamLink::ProjectionClipping m_clipping;
-    FTextureRHIRef m_bufTexture;
+    RenderStreamLink::TexturesRHIRef m_bufTextures;
     FIntPoint m_resolution;
     RenderStreamLink::StreamHandle m_handle;
 };

--- a/Source/RenderStream/Public/RenderStreamCapturePostProcess.h
+++ b/Source/RenderStream/Public/RenderStreamCapturePostProcess.h
@@ -4,6 +4,7 @@
 #include "Render/PostProcess/IDisplayClusterPostProcessFactory.h"
 #include "Render/PostProcess/IDisplayClusterPostProcess.h"
 
+
 DECLARE_LOG_CATEGORY_EXTERN(LogRenderStreamPostProcess, Log, All);
 
 /**

--- a/Source/RenderStream/Public/RenderStreamCapturePostProcess.h
+++ b/Source/RenderStream/Public/RenderStreamCapturePostProcess.h
@@ -7,6 +7,8 @@
 
 DECLARE_LOG_CATEGORY_EXTERN(LogRenderStreamPostProcess, Log, All);
 
+class FRenderStreamSceneViewExtension;
+
 /**
  * 'renderstream' policy for disguise integration
  */
@@ -32,6 +34,7 @@ public:
 private:
 	TMap<FString, FString> Parameters;
 	FString Id;
+    TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> ViewExtension = nullptr;
 };
 
 class FRenderStreamPostProcessFactory

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <memory>
+#include <vector>
 
 struct ID3D11Device;
 struct ID3D12Device;
@@ -128,6 +129,7 @@ public:
     {
         double tTracked;
         CameraData camera;
+        std::vector<uint8_t> depth;
     } CameraResponseData;
 
 

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -30,8 +30,6 @@ public:
 
         RS_FMT_RGBA8,
         RS_FMT_RGBX8,
-
-        RS_FMT_R32F
     };
 
     enum RS_ERROR

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -30,6 +30,8 @@ public:
 
         RS_FMT_RGBA8,
         RS_FMT_RGBX8,
+
+        RS_FMT_R32F
     };
 
     enum RS_ERROR
@@ -160,6 +162,25 @@ public:
         OpenGlData gl;
     } SenderFrameTypeData;
 
+    typedef struct
+    {
+        SenderFrameTypeData colour;
+        SenderFrameTypeData depth;
+    } SenderFrameTypeDataStruct;
+    
+    typedef struct
+    {
+        FRHITexture2D* Colour;
+        FRHITexture2D* Depth;
+    } Textures;
+
+    typedef struct
+    {
+        FTextureRHIRef Colour;
+        FTextureRHIRef Depth;
+    } TexturesRHIRef;
+
+    
     typedef struct
     {
         uint32_t xOffset;
@@ -348,7 +369,7 @@ private:
     typedef RS_ERROR rs_getFrameTextFn(uint64_t schemaHash, uint32_t textParamIndex, /*Out*/const char** outTextPtr); // // returns the remote text data (pointer only valid until next rs_awaitFrameData)
 
     typedef RS_ERROR rs_getFrameCameraFn(StreamHandle streamHandle, /*Out*/CameraData* outCameraData);  // returns the CameraData for this stream, or RS_ERROR_NOTFOUND if no camera data is available for this stream on this frame
-    typedef RS_ERROR rs_sendFrameFn(StreamHandle streamHandle, SenderFrameType frameType, SenderFrameTypeData data, const CameraResponseData* sendData); // publish a frame buffer which was generated from the associated tracking and timing information.
+    typedef RS_ERROR rs_sendFrameFn(StreamHandle streamHandle, SenderFrameType frameType, SenderFrameTypeDataStruct data, const CameraResponseData* sendData); // publish a frame buffer which was generated from the associated tracking and timing information.
 
     typedef RS_ERROR rs_logToD3Fn(const char * str);
     typedef RS_ERROR rs_sendProfilingDataFn(ProfilingEntry* entries, int count);

--- a/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
+++ b/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
@@ -1,0 +1,38 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "SceneViewExtension.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogRenderStreamViewExtension, Log, All);
+
+class FRenderStreamSceneViewExtension : public FSceneViewExtensionBase
+{
+public:
+
+    FRenderStreamSceneViewExtension(const FAutoRegister& AutoRegister);
+    ~FRenderStreamSceneViewExtension();
+
+    static TSharedPtr<FRenderStreamSceneViewExtension, ESPMode::ThreadSafe> Create();
+
+    // dummy overrides
+    virtual void SetupViewFamily(FSceneViewFamily& InViewFamily) {}
+    virtual void SetupView(FSceneViewFamily& InViewFamily, FSceneView& InView) {}
+    virtual void BeginRenderViewFamily(FSceneViewFamily& InViewFamily) {}
+    virtual void PreRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily) {}
+    virtual void PreRenderView_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) {}
+    
+    // meat and potatoes
+    virtual void PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily);
+    virtual void PostRenderBasePass_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) override;
+	
+    static void copyToIntermediateBuffer_RenderThread(FRHICommandListImmediate& RHICmdList, FTexture2DRHIRef& Src, FTexture2DRHIRef& Dst);
+    
+    FTexture2DRHIRef getExtractedDepth();
+
+public:
+    FTexture2DRHIRef m_intermediateDepth;
+
+};

--- a/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
+++ b/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
@@ -25,12 +25,14 @@ public:
     virtual void PreRenderView_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) {}
     
     // meat and potatoes
-    virtual void PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily);
+    virtual void PostRenderViewFamily_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneViewFamily& InViewFamily) override;
     virtual void PostRenderBasePass_RenderThread(FRHICommandListImmediate& RHICmdList, FSceneView& InView) override;
 	
     static void copyToIntermediateBuffer_RenderThread(FRHICommandListImmediate& RHICmdList, FTexture2DRHIRef& Src, FTexture2DRHIRef& Dst);
     
     FTexture2DRHIRef getExtractedDepth();
+
+    bool IsActiveThisFrame_Internal(const FSceneViewExtensionContext& Context) const override;
 
 public:
     FTexture2DRHIRef m_intermediateDepth;

--- a/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
+++ b/Source/RenderStream/Public/RenderStreamSceneViewExtension.h
@@ -36,5 +36,6 @@ public:
 
 public:
     FTexture2DRHIRef m_intermediateDepth;
+    bool m_depthEnabled;
 
 };

--- a/Source/RenderStream/RenderStream.Build.cs
+++ b/Source/RenderStream/RenderStream.Build.cs
@@ -34,6 +34,7 @@ public class RenderStream : ModuleRules
                 "D3D11RHI", 
                 "D3D12RHI", 
                 "RenderCore", 
+                "Renderer",
                 "Projects", 
                 "Json", 
                 "JsonUtilities", 
@@ -46,7 +47,9 @@ public class RenderStream : ModuleRules
             {
                 Path.Combine(EngineDirectory, "Source/Runtime/D3D12RHI/Private"),
                 Path.Combine(EngineDirectory, "Source/Runtime/D3D12RHI/Private/Windows"),
-                Path.Combine(EngineDirectory, "Source/ThirdParty/Windows/D3DX12/Include")
+                Path.Combine(EngineDirectory, "Source/ThirdParty/Windows/D3DX12/Include"),
+                Path.Combine(EngineDirectory, "Source/Runtime/Renderer/Private"),
+                Path.Combine(EngineDirectory, "Source/Runtime/Renderer/Private/PostProcess")
             });
 
         DynamicallyLoadedModuleNames.AddRange(new string[] { });


### PR DESCRIPTION
UE4 side for depth compression demonstration. Extends the sendFrame stuff to include sending a depth texture, adds a SceneViewExtension to hook into the render process after the base pass.