### PR TITLE
Asset caching performance improvement

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -129,7 +129,7 @@ void FRenderStreamEditorModule::DeleteCaches(const TArray<FAssetData>& InCachesT
     }
 
     if (Objects.Num() > 0) // Actually stalls for ages even if empty.
-		ObjectTools::DeleteObjectsUnchecked(ObjectsToDelete);
+		ObjectTools::DeleteObjectsUnchecked(Objects);
         //ObjectTools::ForceDeleteObjects(Objects, false);
 }
 
@@ -545,7 +545,8 @@ bool RemoveInvalidCacheEntries()
 
     const auto RemoveCount = ChannelCaches.RemoveAll(IsInvalidCacheAsset);
     if (RemoveCount > 0)
-        ObjectTools::ForceDeleteObjects(ObjectsToDelete, false);
+		ObjectTools::DeleteObjectsUnchecked(ObjectsToDelete);
+        //ObjectTools::ForceDeleteObjects(ObjectsToDelete, false);
 
     return RemoveCount > 0;
 }

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -128,9 +128,8 @@ void FRenderStreamEditorModule::DeleteCaches(const TArray<FAssetData>& InCachesT
         }
     }
 
-    if (Objects.Num() > 0) // Actually stalls for ages even if empty.
-		ObjectTools::DeleteObjectsUnchecked(Objects);
-        //ObjectTools::ForceDeleteObjects(Objects, false);
+    if (Objects.Num() > 0)
+        ObjectTools::DeleteObjectsUnchecked(Objects);
 }
 
 void CreateFieldInternal(FRenderStreamExposedParameterEntry& parameter, FString group, FString displayName_, FString suffix, FString key_, FString undecoratedSuffix, RenderStreamParameterType type, float min = 0.f, float max = 255.f, float step = 1.f, FString defaultValue = "0", TArray<FString> options = {})
@@ -487,7 +486,6 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     // Save the Cache.
     UPackage* Package = Cache->GetPackage();
     Package->MarkPackageDirty();
-    //FAssetRegistryModule::AssetCreated(Cache);
     const FString PackageFileName = FPackageName::LongPackageNameToFilename(CacheFolder + LevelPath, FPackageName::GetAssetPackageExtension());
     bool bSaved = UPackage::SavePackage(
         Package,
@@ -545,8 +543,7 @@ bool RemoveInvalidCacheEntries()
 
     const auto RemoveCount = ChannelCaches.RemoveAll(IsInvalidCacheAsset);
     if (RemoveCount > 0)
-		ObjectTools::DeleteObjectsUnchecked(ObjectsToDelete);
-        //ObjectTools::ForceDeleteObjects(ObjectsToDelete, false);
+        ObjectTools::DeleteObjectsUnchecked(ObjectsToDelete);
 
     return RemoveCount > 0;
 }

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -129,7 +129,8 @@ void FRenderStreamEditorModule::DeleteCaches(const TArray<FAssetData>& InCachesT
     }
 
     if (Objects.Num() > 0) // Actually stalls for ages even if empty.
-        ObjectTools::ForceDeleteObjects(Objects, false);
+		ObjectTools::DeleteObjectsUnchecked(ObjectsToDelete);
+        //ObjectTools::ForceDeleteObjects(Objects, false);
 }
 
 void CreateFieldInternal(FRenderStreamExposedParameterEntry& parameter, FString group, FString displayName_, FString suffix, FString key_, FString undecoratedSuffix, RenderStreamParameterType type, float min = 0.f, float max = 255.f, float step = 1.f, FString defaultValue = "0", TArray<FString> options = {})
@@ -486,7 +487,7 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     // Save the Cache.
     UPackage* Package = Cache->GetPackage();
     Package->MarkPackageDirty();
-    FAssetRegistryModule::AssetCreated(Cache);
+    //FAssetRegistryModule::AssetCreated(Cache);
     const FString PackageFileName = FPackageName::LongPackageNameToFilename(CacheFolder + LevelPath, FPackageName::GetAssetPackageExtension());
     bool bSaved = UPackage::SavePackage(
         Package,


### PR DESCRIPTION
**DO NOT MERGE as this still needs to be tested by client if it actually helps**

**Issue:**
When using a multiuser editing session with multiple rx's and an editor machine, the constant resaving of the RenderstreamChannelCacheAsset causes the multi user session and Renderstream to crash. This only seems to be an issue when using multiple heavy sublevels as it take a long time to save all the individual cache assets for each sublevel. 

**Profiling:**
During profiling I noticed that **ForceDeleteObjects** function was stalling main thread a lot because it was force replacing references and we don't want to do that.
**AssetCreated** function was taking some amount of time too even though it just broadcasting that new in memory asset is created 

Before changes:
![image](https://user-images.githubusercontent.com/10357361/184898927-834025a2-d408-4edc-98fa-b172e6a60c7a.png)

After changes:
![image](https://user-images.githubusercontent.com/10357361/184898691-a1821a03-8786-45d3-8789-d4cabbeefa4e.png)