### PR TITLE
RSP-247 allow disabling custom event control

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -9,6 +9,7 @@
 #include "RenderStreamHelper.h"
 #include "RSUCHelpers.inl"
 #include "Engine/LevelStreaming.h"
+#include "RenderStreamSettings.h"
 
 #include "RenderCore/Public/ProfilingDebugging/RealtimeGPUProfiler.h"
 
@@ -146,20 +147,25 @@ size_t RenderStreamSceneSelector::ValidateParameters(const AActor* Root, RenderS
 {
     size_t nParameters = 0;
 
-    for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+
+    if (settings->GenerateEvents)
     {
-        if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
         {
-            const FString Name = FuncIt->GetName();
-            UE_LOG(LogRenderStream, Log, TEXT("Exposed custom event: %s"), *Name);
-            if (numParameters < nParameters + 1)
+            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
             {
-                UE_LOG(LogRenderStream, Error, TEXT("Property %s not exposed in schema"), *Name);
-                return SIZE_MAX;
+                const FString Name = FuncIt->GetName();
+                UE_LOG(LogRenderStream, Log, TEXT("Exposed custom event: %s"), *Name);
+                if (numParameters < nParameters + 1)
+                {
+                    UE_LOG(LogRenderStream, Error, TEXT("Property %s not exposed in schema"), *Name);
+                    return SIZE_MAX;
+                }
+                if (!validateField(Name, "", RenderStreamLink::RS_PARAMETER_EVENT, parameters[nParameters]))
+                    return SIZE_MAX;
+                ++nParameters;
             }
-            if (!validateField(Name, "", RenderStreamLink::RS_PARAMETER_EVENT, parameters[nParameters]))
-                return SIZE_MAX;
-            ++nParameters;
         }
     }
 
@@ -433,20 +439,25 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
     const float* floatValues = *ppFloatValues;
     const RenderStreamLink::ImageFrameData* imageValues = *ppImageValues;
 
-    for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+
+    if (settings->GenerateEvents)
     {
-        if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
         {
-            if (!m_floatValuesLast.data()) // first frame
-                break;
-            if (floatValues[iFloat] > m_floatValuesLast.data()[iFloat]) // value increment signals an invoke
+            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
             {
-                uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
-                FFrame Frame = FFrame(Root, *FuncIt, Buffer);
-                FuncIt->Invoke(Root, Frame, Buffer);
-                UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
+                if (!m_floatValuesLast.data()) // first frame
+                    break;
+                if (floatValues[iFloat] > m_floatValuesLast.data()[iFloat]) // value increment signals an invoke
+                {
+                    uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
+                    FFrame Frame = FFrame(Root, *FuncIt, Buffer);
+                    FuncIt->Invoke(Root, Frame, Buffer);
+                    UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
+                }
+                ++iFloat;
             }
-            ++iFloat;
         }
     }
 

--- a/Source/RenderStream/Private/RenderStreamSettings.cpp
+++ b/Source/RenderStream/Private/RenderStreamSettings.cpp
@@ -5,4 +5,5 @@
 URenderStreamSettings::URenderStreamSettings(const FObjectInitializer& ObjectInitializer)
     : Super(ObjectInitializer)
     , SceneSelector(ERenderStreamSceneSelector::None)
+    , GenerateEvents(true)
 {}

--- a/Source/RenderStream/Public/RenderStreamSettings.h
+++ b/Source/RenderStream/Public/RenderStreamSettings.h
@@ -39,4 +39,7 @@ public:
 
     UPROPERTY(EditAnywhere, config, Category = Settings)
     FOpenColorIODisplayConfiguration OCIOConfig;
+
+    UPROPERTY(EditAnywhere, config, Category = Settings, DisplayName="Detect and control custom events")
+    bool GenerateEvents;
 };

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -233,16 +233,22 @@ void GenerateParameters(TArray<FRenderStreamExposedParameterEntry>& Parameters, 
 {
     if (!Root)
         return;
-    for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+    if (settings->GenerateEvents)
     {
-        if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
         {
-            const FString Name = FuncIt->GetName();
-            const FString Category = "Custom Events";
-            UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed custom event: %s"), *Name);
-            CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Event);
+            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+            {
+                const FString Name = FuncIt->GetName();
+                const FString Category = "Custom Events";
+                UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed custom event: %s"), *Name);
+                CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Event);
+            }
         }
     }
+
     for (TFieldIterator<FProperty> PropIt(Root->GetClass(), EFieldIteratorFlags::ExcludeSuper); PropIt; ++PropIt)
     {
         const FProperty* Property = *PropIt;


### PR DESCRIPTION
This patch adds a toggle box in the project plugin settings under 'Disguise Renderstream' called "Detect and control custom events". When this toggle is off, the Renderstream plugin will not export custom events in the schema or attempt to trigger them at runtime. For RSP-247, DSOF-22487