### PR TITLE
Custom events safety UE 5.0

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -481,8 +481,20 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                 {
                     uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
                     FFrame Frame = FFrame(Root, *FuncIt, Buffer);
-                    FuncIt->Invoke(Root, Frame, Buffer);
-                    UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
+                    try
+                    {
+                        FuncIt->Invoke(Root, Frame, Buffer);
+                        UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
+                    }
+                    catch (const std::exception& e)
+                    {
+                        FString Message(e.what());
+                        UE_LOG(LogRenderStream, Error, TEXT("Error invoking event: %s"), *Message);
+                    }
+                    catch (...)
+                    {
+                        UE_LOG(LogRenderStream, Error, TEXT("Unknown error invoking event"));
+                    }
                 }
                 ++iFloat;
             }

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -480,11 +480,10 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                 if (floatValues[iFloat] > m_floatValuesLast.data()[iFloat]) // value increment signals an invoke
                 {
                     uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
-                    FFrame Frame = FFrame(Root, *FuncIt, Buffer);
                     try
                     {
-                        FuncIt->Invoke(Root, Frame, Buffer);
-                        UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
+                        UE_LOG(LogRenderStream, Verbose, TEXT("Invoking Event %s/%s"), *Root->GetName(), *FuncIt->GetName());
+                        Root->ProcessEvent(*FuncIt, Buffer);
                     }
                     catch (const std::exception& e)
                     {

--- a/Source/RenderStream/RenderStream.Build.cs
+++ b/Source/RenderStream/RenderStream.Build.cs
@@ -66,6 +66,8 @@ public class RenderStream : ModuleRules
         //AddEngineThirdPartyPrivateStaticDependencies(Target, "NVAftermath");
         //AddEngineThirdPartyPrivateStaticDependencies(Target, "IntelMetricsDiscovery");	}
 
+        bEnableExceptions = true;
+
         //using (var md5 = MD5.Create())
         //{
         //    using (var stream = File.OpenRead(Path.Combine(EngineDirectory, "Plugins/Runtime/nDisplay/Source/DisplayCluster/Private/Game/EngineClasses/Basics/DisplayClusterViewportClient.cpp")))


### PR DESCRIPTION
Use an alternative way to invoke custom events to avoid UE CTD on custom event exceptions.