### PR TITLE
Plugin MultiUserClient Fails To Load When Launching A Project With The RenderStream Plugin

### DIFF
--- a/uplugin_template.json
+++ b/uplugin_template.json
@@ -49,6 +49,10 @@
 		{
 			"Name": "nDisplay",
 			"Enabled": true
+		},
+		{
+			"Name": "ConcertSyncClient",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
A plugin that MultiUserClient requires does not get enabled by default so this change forces that plugin (ConcertSyncClient) to be enabled in the plugin template so everything can load properly.