### PR TITLE
26833 allow custom events trigger on first frame

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -498,7 +498,8 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                 int oldValue = m_floatValuesLast.size() > iFloat ? m_floatValuesLast[iFloat] : 0;
                 int newValue = floatValues[iFloat];
                 if (newValue > oldValue) // value increment signals an invoke
-                {                           // TODO: should we invoke once per increment? e.g. oldValue == 0, newValue == 5 => 1 invoke or 5 invokes?
+                {
+                    // TODO: should we invoke once per increment? e.g. oldValue == 0, newValue == 5 => 1 invoke or 5 invokes?
                     uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
                     FFrame Frame = FFrame(Root, *FuncIt, Buffer);
                     FuncIt->Invoke(Root, Frame, Buffer);

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -495,10 +495,10 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
         {
             if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
             {
-                if (!m_floatValuesLast.data()) // first frame
-                    break;
-                if (floatValues[iFloat] > m_floatValuesLast.data()[iFloat]) // value increment signals an invoke
-                {
+                int oldValue = m_floatValuesLast.size() > iFloat ? m_floatValuesLast[iFloat] : 0;
+                int newValue = floatValues[iFloat];
+                if (newValue > oldValue) // value increment signals an invoke
+                {                           // TODO: should we invoke once per increment? e.g. oldValue == 0, newValue == 5 => 1 invoke or 5 invokes?
                     uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
                     FFrame Frame = FFrame(Root, *FuncIt, Buffer);
                     FuncIt->Invoke(Root, Frame, Buffer);


### PR DESCRIPTION
DSOF-26833
Allow custom event triggering on the first frame to avoid missing custom event triggers.