### PR TITLE
Support for 12 bit Vulkan

### DIFF
--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -215,6 +215,9 @@ namespace RSUCHelpers
                 case EPixelFormat::PF_R8G8B8A8:
                     fmt = RenderStreamLink::RS_FMT_RGBA8;
                     break;
+                case EPixelFormat::PF_A32B32G32R32F:
+                    fmt = RenderStreamLink::RS_FMT_RGBA32F;
+                    break;
                 default:
                     UE_LOG(LogRenderStream, Error, TEXT("RenderStream tried to send frame with unsupported format."));
                     return;


### PR DESCRIPTION
Part of the fix for [DSOF-27751](https://d3technologies.atlassian.net/browse/DSOF-27751)

Added conversion from `PF_A32B32G32R32F` UE format to `RSPixelFormat` since we use it for 12 bit Vulkan textures.

[DSOF-27751]: https://d3technologies.atlassian.net/browse/DSOF-27751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ