### PR TITLE
Adds nullptr checking when caching levels

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -622,9 +622,14 @@ void UpdateChannelCache()
         URenderStreamChannelCacheAsset* Cache;
         if (!TryGetCache(CacheFolder + Asset.GetFullName(), Cache)) {
             auto world = Cast<UWorld>(Asset.FastGetAsset(true));
-            if (world->GetNumLevels() > 0)
+			UE_LOG(LogRenderStreamEditor, Verbose, TEXT("Caching level: %s"), *Asset.GetFullName());
+            if (world != nullptr && world->GetNumLevels() > 0)
             {
                 Cache = UpdateLevelChannelCache(world->GetLevel(0));
+            }
+            else
+            {
+				UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to load level: %s. Open and re-save this level to attempt fixing the issue."), *Asset.GetFullName());
             }
         }
     }


### PR DESCRIPTION
Assets are loaded and cast to UWorld. Under certain situations, such as copy-pasting world assets manually, this procedure may return a nullptr. Without nullptr checking, an access violation crashes Unreal Engine.

Here we catch nullptr and log an appropriate error message for the user.

RSP-348