### PR TITLE
Updated plugin to be compatible with UE 5.5

### DIFF
--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -79,7 +79,7 @@ namespace {
         }
 
         TUniformBufferRef<RSResizeCopyUB> Data = TUniformBufferRef<RSResizeCopyUB>::CreateUniformBufferImmediate(UB, UniformBuffer_SingleFrame);
-        FRHIBatchedShaderParameters Params;
+        FRHIBatchedShaderParameters Params = CommandList.GetScratchShaderParameters();
         SetUniformBufferParameter(Params, GetUniformBufferParameter<RSResizeCopyUB>(), Data);
         CommandList.SetBatchedShaderParameters(CommandList.GetBoundPixelShader(), Params);
     }

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -688,6 +688,10 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     RenderStreamLink::SenderFrame data = {};
                     if (toggle == "D3D11")
                     {
+                        {
+                            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
+                            RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
+                        }
                         data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX11_TEXTURE;
                         data.dx11.resource = static_cast<ID3D11Resource*>(resource);
                         auto err = RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data);

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v1"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v0"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v0"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v1"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v1"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v1"
 
 class RenderStreamLink
 {

--- a/Source/RenderStreamEditor/Private/RenderStreamCustomization.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamCustomization.cpp
@@ -458,31 +458,34 @@
 
     void FSettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
     {
-        const TSharedRef<IPropertyHandle> Property = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(URenderStreamSettings, SceneSelector));
-        if (Property->IsValidHandle())
-        {
-            TArray<TWeakObjectPtr<UObject>> Objects;
-            DetailBuilder.GetObjectsBeingCustomized(Objects);
-            IDetailCategoryBuilder& Category = DetailBuilder.EditCategory("Scene Selection");
+        // This code prehibits the SceneSelection to be saved to the DefaultEngine.ini file for an unknown reason in UE 5.5
+        // This is possibly a bug in the SaveConfig() function
 
-            Property->MarkHiddenByCustomization();
-            Property->MarkResetToDefaultCustomized();
-            FDetailWidgetRow& SceneSelectionRow = Category.AddCustomRow(FText::FromString("Scene Selection"));
+        // const TSharedRef<IPropertyHandle> Property = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(URenderStreamSettings, SceneSelector));
+        // if (Property->IsValidHandle())
+        // {
+        //     TArray<TWeakObjectPtr<UObject>> Objects;
+        //     DetailBuilder.GetObjectsBeingCustomized(Objects);
+        //     IDetailCategoryBuilder& Category = DetailBuilder.EditCategory("Scene Selection");
 
-            SceneSelectionRow
-                .NameContent()
-                [
-                    SNew(STextBlock)
-                    .Text(LOCTEXT("Scene Selection", "Scene Selection"))
-                    .Font(IDetailLayoutBuilder::GetDetailFont())
-                ]
-            .ValueContent()
-                .HAlign(HAlign_Fill)
-                [
-                    SNew(SSceneSelectionCombo)
-                    .SceneSelection(Objects)
-                ];
-        }
+        //     // Property->MarkHiddenByCustomization();
+        //     // Property->MarkResetToDefaultCustomized();
+        //     FDetailWidgetRow& SceneSelectionRow = Category.AddCustomRow(FText::FromString("Scene Selection"));
+
+        //     SceneSelectionRow
+        //         .NameContent()
+        //         [
+        //             SNew(STextBlock)
+        //             .Text(LOCTEXT("Scene Selection", "Scene Selection"))
+        //             .Font(IDetailLayoutBuilder::GetDetailFont())
+        //         ]
+        //     .ValueContent()
+        //         .HAlign(HAlign_Fill)
+        //         [
+        //             SNew(SSceneSelectionCombo)
+        //             .SceneSelection(Objects)
+        //         ];
+        // }
     }
 
 

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -540,15 +540,22 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     Cache->ExposedParams.Empty();
     GenerateParameters(Cache->ExposedParams, Level->GetLevelScriptActor());
 
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+
     // We can only know the sublevels of the persistent level.
     if (Level->IsPersistentLevel())
     {
         Cache->SubLevels.Empty();
-        for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
+        
+        // Sublevels are not loaded when SceneSelector is None so they shouldn't be added to the cache
+        if (settings->SceneSelector != ERenderStreamSceneSelector::None)
         {
-            if (auto WorldAsset = SubLevel->GetWorldAsset())
+            for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
             {
-                Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                if (auto WorldAsset = SubLevel->GetWorldAsset())
+                {
+                    Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                }
             }
         }
     }

--- a/uplugin_template.json
+++ b/uplugin_template.json
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.4.0",
+	"EngineVersion": "5.5.0",
 	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
[RSP-351](https://d3technologies.atlassian.net/browse/RSP-351)

**Technical Description:**
The RenderStream UE plugin currently only supports up to UE 5.4, this change allows the plugin to be compatible with UE 5.5. The FRHIBatchedShaderParameters struct is no longer allowed to be default constructed. There is also an issue with settings not being able to be saved to the DefaultEngine.ini file. This is because of some unknown issue with using SaveConfig() on these settings.

**Resolution Details:**
We can instantiate the FRHIBatchedShaderParameters struct using the command list that is already being passed into the function where the issue is. 

The workaround for saving settings is to not use SaveConfig(), currently we use a customization class to extend the SceneSelection setting so that when it is changed we can have a callback to generate new metadata. This however also requires the use of SaveConfig() in this callback since it won't be saved otherwise. The solution is just to exclude this customization code for now since the plugin already is checking separately for changes in the settings and will generate the metadata on shutdown. See FRenderStreamEditorModule::OnObjectPostEditChange and FRenderStreamEditorModule::OnShutdownPostPackagesSaved(). 

**Test Guidance:**
UE 5.5 assets should work with RenderStream. The dx11 issue was fixed with UE version 5.5.1.

[RSP-351]: https://d3technologies.atlassian.net/browse/RSP-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ