### PR TITLE
Ensure events and properties are ordered consistently

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -58,6 +58,50 @@ enum RenderStreamSceneSelector::SchemaStatus RenderStreamSceneSelector::SchemaSt
     return SchemaStatus::Loaded;
 }
 
+TArray<UFunction*> RenderStreamSceneSelector::GetEvents(const AActor* rootActor)
+{
+    TArray<UFunction*> out;
+
+    for (TFieldIterator<UFunction> FuncIt(rootActor->GetClass()); FuncIt; ++FuncIt)
+    {
+        if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+        {
+            out.Add(*FuncIt);
+        }
+    }
+
+    // The events seem to be iterated in a random order depending on whether we are in editor or game mode.
+    // The sort key doesn't matter, it just needs to be consistent.
+    out.Sort([](const UFunction& a, const UFunction& b) {
+        return a.GetName() < b.GetName();
+    });
+
+    return out;
+}
+
+TArray<FProperty*> RenderStreamSceneSelector::GetProperties(const AActor* rootActor)
+{
+    TArray<FProperty*> out;
+    for (TFieldIterator<FProperty> PropIt(rootActor->GetClass(), EFieldIteratorFlags::ExcludeSuper); PropIt; ++PropIt)
+    {
+        if (!PropIt->HasAllPropertyFlags(CPF_Edit | CPF_BlueprintVisible) || PropIt->HasAllPropertyFlags(CPF_DisableEditOnInstance))
+        {
+            continue;
+        }
+
+        out.Add(*PropIt);
+    }
+
+    // While no properties have been reported to be produced out of order, due to the issue with iterating functions
+    // in `GetEvents`, it seems sensible to sort properties in a consistent (alphabetical) order, too.
+    // The sort key doesn't matter, it just needs to be consistent.
+    out.Sort([](const FProperty& a, const FProperty& b) {
+        return a.GetName() < b.GetName();
+    });
+
+    return out;
+}
+
 const RenderStreamLink::Schema& RenderStreamSceneSelector::Schema() const
 {
     if (!m_schemaMem.empty())
@@ -172,33 +216,25 @@ size_t RenderStreamSceneSelector::ValidateParameters(const AActor* Root, RenderS
 
     if (settings->GenerateEvents)
     {
-        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+        for (UFunction* func : GetEvents(Root))
         {
-            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+            const FString Name = func->GetName();
+            UE_LOG(LogRenderStream, Log, TEXT("Exposed custom event: %s"), *Name);
+            if (numParameters < nParameters + 1)
             {
-                const FString Name = FuncIt->GetName();
-                UE_LOG(LogRenderStream, Log, TEXT("Exposed custom event: %s"), *Name);
-                if (numParameters < nParameters + 1)
-                {
-                    UE_LOG(LogRenderStream, Error, TEXT("Property %s not exposed in schema"), *Name);
-                    return SIZE_MAX;
-                }
-                if (!validateField(Name, "", RenderStreamLink::RS_PARAMETER_EVENT, parameters[nParameters]))
-                    return SIZE_MAX;
-                ++nParameters;
+                UE_LOG(LogRenderStream, Error, TEXT("Property %s not exposed in schema"), *Name);
+                return SIZE_MAX;
             }
+            if (!validateField(Name, "", RenderStreamLink::RS_PARAMETER_EVENT, parameters[nParameters]))
+                return SIZE_MAX;
+            ++nParameters;
         }
     }
 
-    for (TFieldIterator<FProperty> PropIt(Root->GetClass(), EFieldIteratorFlags::ExcludeSuper); PropIt; ++PropIt)
+    for (FProperty* Property : RenderStreamSceneSelector::GetProperties(Root))
     {
-        const FProperty* Property = *PropIt;
         const FString Name = Property->GetName();
-        if (!Property->HasAllPropertyFlags(CPF_Edit | CPF_BlueprintVisible) || Property->HasAllPropertyFlags(CPF_DisableEditOnInstance))
-        {
-            UE_LOG(LogRenderStream, Verbose, TEXT("Unexposed property: %s"), *Name);
-        }
-        else if (const FBoolProperty* BoolProperty = CastField<const FBoolProperty>(Property))
+        if (const FBoolProperty* BoolProperty = CastField<const FBoolProperty>(Property))
         {
             UE_LOG(LogRenderStream, Log, TEXT("Exposed bool property: %s"), *Name);
             if (numParameters < nParameters + 1)
@@ -502,31 +538,24 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
 
     if (settings->GenerateEvents)
     {
-        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+        for (UFunction* func : GetEvents(Root))
         {
-            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
+            int oldValue = m_floatValuesLast.size() > iFloat ? m_floatValuesLast[iFloat] : 0;
+            int newValue = floatValues[iFloat];
+            if (newValue > oldValue) // value increment signals an invoke
             {
-                int oldValue = m_floatValuesLast.size() > iFloat ? m_floatValuesLast[iFloat] : 0;
-                int newValue = floatValues[iFloat];
-                if (newValue > oldValue) // value increment signals an invoke
-                {
-                    // TODO: should we invoke once per increment? e.g. oldValue == 0, newValue == 5 => 1 invoke or 5 invokes?
-                    uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(FuncIt->ParmsSize));
-                    FFrame Frame = FFrame(Root, *FuncIt, Buffer);
-                    FuncIt->Invoke(Root, Frame, Buffer);
-                    UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
-                }
-                ++iFloat;
+                // TODO: should we invoke once per increment? e.g. oldValue == 0, newValue == 5 => 1 invoke or 5 invokes?
+                uint8* Buffer = static_cast<uint8*>(FMemory_Alloca(func->ParmsSize));
+                FFrame Frame = FFrame(Root, func, Buffer);
+                func->Invoke(Root, Frame, Buffer);
+                UE_LOG(LogRenderStream, Verbose, TEXT("Event Invoked"));
             }
+            ++iFloat;
         }
     }
 
-    for (TFieldIterator<FProperty> PropIt(Root->GetClass(), EFieldIteratorFlags::ExcludeSuper); PropIt && iParam < nParams; ++PropIt)
+    for (FProperty* Property : RenderStreamSceneSelector::GetProperties(Root))
     {
-        FProperty* Property = *PropIt;
-        if (!Property->HasAllPropertyFlags(CPF_Edit | CPF_BlueprintVisible) || Property->HasAllPropertyFlags(CPF_DisableEditOnInstance))
-            continue;
-
         if (Property->IsA(FBoolProperty::StaticClass()) ||
             Property->IsA(FByteProperty::StaticClass()) ||
             Property->IsA(FIntProperty::StaticClass()) ||

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -7,7 +7,7 @@ class UWorld;
 class AActor;
 
 // Select a scene within the project, provide and apply parameters.
-class RenderStreamSceneSelector
+class RENDERSTREAM_API RenderStreamSceneSelector
 {
 public:
     virtual ~RenderStreamSceneSelector();
@@ -22,6 +22,10 @@ public:
     };
 
     SchemaStatus SchemaStatus() const;
+
+public: // static helpers
+    static TArray<UFunction*> GetEvents(const AActor* rootActor);
+    static TArray<FProperty*> GetProperties(const AActor* rootActor);
 
 protected:
     const RenderStreamLink::Schema& Schema() const;

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -22,6 +22,7 @@
 #include "RenderStreamChannelCacheAsset.h"
 #include "RenderStreamChannelDefinition.h"
 #include "RenderStreamCustomization.h"
+#include "RenderStreamSceneSelector.h"
 #include "RenderStreamSettings.h"
 #include "RenderStreamValidation.h"
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -250,28 +251,20 @@ void GenerateParameters(TArray<FRenderStreamExposedParameterEntry>& Parameters, 
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
     if (settings->GenerateEvents)
     {
-        for (TFieldIterator<UFunction> FuncIt(Root->GetClass()); FuncIt; ++FuncIt)
+        for (UFunction* func : RenderStreamSceneSelector::GetEvents(Root))
         {
-            if (FuncIt->HasAnyFunctionFlags(FUNC_BlueprintEvent) && FuncIt->HasAnyFunctionFlags(FUNC_BlueprintCallable))
-            {
-                const FString Name = FuncIt->GetName();
-                const FString Category = "Custom Events";
-                UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed custom event: %s"), *Name);
-                CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Event);
-            }
+            const FString Name = func->GetName();
+            const FString Category = "Custom Events";
+            UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed custom event: %s"), *Name);
+            CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Event);
         }
     }
 
-    for (TFieldIterator<FProperty> PropIt(Root->GetClass(), EFieldIteratorFlags::ExcludeSuper); PropIt; ++PropIt)
+    for (FProperty* Property : RenderStreamSceneSelector::GetProperties(Root))
     {
-        const FProperty* Property = *PropIt;
         const FString Name = Property->GetName();
         const FString Category = Property->GetMetaData("Category");
-        if (!Property->HasAllPropertyFlags(CPF_Edit | CPF_BlueprintVisible) || Property->HasAllPropertyFlags(CPF_DisableEditOnInstance))
-        {
-            UE_LOG(LogRenderStreamEditor, Verbose, TEXT("Unexposed property: %s"), *Name);
-        }
-        else if (const FBoolProperty* BoolProperty = CastField<const FBoolProperty>(Property))
+        if (const FBoolProperty* BoolProperty = CastField<const FBoolProperty>(Property))
         {
             const bool v = BoolProperty->GetPropertyValue_InContainer(Root);
             UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed bool property: %s is %d"), *Name, v);


### PR DESCRIPTION
Caused issues with a show when using a large number of custom events. Unclear why this suddenly happened. It seems game mode and editor mode iterate the blueprint actor class in different orders, at least for the events. I sorted the properties too, as a belt-and-braces approach.
[RSP-359](https://d3technologies.atlassian.net/browse/RSP-359)

[RSP-359]: https://d3technologies.atlassian.net/browse/RSP-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ