### PR TITLE
Exposed parameters don't work

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -451,18 +451,19 @@ void RenderStreamSceneSelector::ApplyParameters(uint32_t sceneId, const TArray<A
     // These are updated by ApplyParameters to allow each actor to operate on the next set of data.
     const RenderStreamLink::RemoteParameter* paramsPtr = params.parameters;
     const float* floatValuesPtr = floatValues.data();
+    size_t textValues = 0;
     const RenderStreamLink::ImageFrameData* imageValuesPtr = imageValues.data();
     for (AActor* actor : Actors)
     {
         if (!actor)
             continue; // it's convenient at the higher level to pass nulls if there's a pattern which can miss pieces
-        ApplyParameters(actor, params.hash, &paramsPtr, params.nParameters, &floatValuesPtr, floatValues.size(), &imageValuesPtr, imageValues.size());
+        ApplyParameters(actor, params.hash, &paramsPtr, params.nParameters, &floatValuesPtr, floatValues.size(), &imageValuesPtr, imageValues.size(), textValues);
     }
 
     m_floatValuesLast = floatValues; // event parameters need to lookup previous values
 }
 
-void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const float** ppFloatValues, const size_t nFloatVals, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals)
+void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const float** ppFloatValues, const size_t nFloatVals, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals, size_t& textValues)
 {
     auto toggle = FHardwareInfo::GetHardwareInfo(NAME_RHI);
     struct
@@ -483,7 +484,6 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
     size_t iParam = 0;
     size_t iFloat = 0;
     size_t iImage = 0;
-    size_t iText = 0;
     size_t iPose = 0;
 
     const float* floatValues = *ppFloatValues;
@@ -716,11 +716,11 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
         else if (const FTextProperty* TextProperty = CastField<const FTextProperty>(Property))
         {
             const char* cString = nullptr;
-            if (RenderStreamLink::instance().rs_getFrameText(specHash, iText, &cString) == RenderStreamLink::RS_ERROR_SUCCESS)
+            if (RenderStreamLink::instance().rs_getFrameText(specHash, textValues, &cString) == RenderStreamLink::RS_ERROR_SUCCESS)
             {
                 TextProperty->SetPropertyValue_InContainer(Root, FText::FromString(UTF8_TO_TCHAR(cString)));
             }
-            ++iText;
+            ++textValues;
         }
         ++iParam;
     }

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -32,7 +32,7 @@ protected:
     void ApplyParameters(uint32_t sceneId, const TArray<AActor*>& Actors);
 private:
     size_t ValidateParameters(const AActor* Root, RenderStreamLink::RemoteParameter* const parameters, size_t numParameters) const;
-    void ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const float** ppFloatValues, const size_t nFloatVals, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals);
+    void ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const float** ppFloatValues, const size_t nFloatVals, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals, size_t& nTextVals);
     void ApplySkeletalPose(uint64_t specHash, size_t iPose, const FString& ParamKey, RenderStreamLink::FAnimDataKey& PropKey);
     
     TMap<uint64_t /*id*/, RenderStreamLink::FSkeletalLayout> m_skeletalLayoutCache;

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -406,11 +406,11 @@ void FetchLevelCaches(
     TMap<FSoftObjectPath, URenderStreamChannelCacheAsset*> const& LevelParams,
     TArray<const URenderStreamChannelCacheAsset*>& Levels,
     const URenderStreamChannelCacheAsset* Parent,
-    bool isPersistentLevel)
+    bool needToFetchSublevels)
 {
     Levels.Push(Parent);
 
-    if (isPersistentLevel)
+    if (!needToFetchSublevels)
         return;
 
     for (FSoftObjectPath Path : Parent->SubLevels)
@@ -430,11 +430,15 @@ void GenerateScene(
     FString sceneName = Cache->GetName();
     SceneParameters.name = _strdup(TCHAR_TO_UTF8(*sceneName));
 
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+    bool isStreamingLevelSceneSelector = settings->SceneSelector == ERenderStreamSceneSelector::StreamingLevels;
+
     TArray<const URenderStreamChannelCacheAsset*> Levels;
-    if (Persistent)
+    if (Persistent && isStreamingLevelSceneSelector) // add persistent level's parameters to sublevels for Streaming level only
         Levels.Push(Persistent);
 
-    FetchLevelCaches(LevelParams, Levels, Cache, !Persistent);
+    bool needToFetchSublevels = settings->SceneSelector == ERenderStreamSceneSelector::None;
+    FetchLevelCaches(LevelParams, Levels, Cache, needToFetchSublevels);
 
     uint32_t nParams = 0;
     for (auto Level : Levels)

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -417,7 +417,7 @@ void FetchLevelCaches(
     {
         URenderStreamChannelCacheAsset* const* Cache = LevelParams.Find(Path);
         if (Cache != nullptr && !Levels.Contains(*Cache))
-            FetchLevelCaches(LevelParams, Levels, *Cache, false);
+            FetchLevelCaches(LevelParams, Levels, *Cache, true);
     }
 }
 

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -405,14 +405,19 @@ void GenerateParameters(TArray<FRenderStreamExposedParameterEntry>& Parameters, 
 void FetchLevelCaches(
     TMap<FSoftObjectPath, URenderStreamChannelCacheAsset*> const& LevelParams,
     TArray<const URenderStreamChannelCacheAsset*>& Levels,
-    const URenderStreamChannelCacheAsset* Parent)
+    const URenderStreamChannelCacheAsset* Parent,
+    bool isPersistentLevel)
 {
     Levels.Push(Parent);
+
+    if (isPersistentLevel)
+        return;
+
     for (FSoftObjectPath Path : Parent->SubLevels)
     {
         URenderStreamChannelCacheAsset* const* Cache = LevelParams.Find(Path);
         if (Cache != nullptr && !Levels.Contains(*Cache))
-            FetchLevelCaches(LevelParams, Levels, *Cache);
+            FetchLevelCaches(LevelParams, Levels, *Cache, false);
     }
 }
 
@@ -426,10 +431,10 @@ void GenerateScene(
     SceneParameters.name = _strdup(TCHAR_TO_UTF8(*sceneName));
 
     TArray<const URenderStreamChannelCacheAsset*> Levels;
-    if (Persistent != nullptr)
+    if (Persistent)
         Levels.Push(Persistent);
 
-    FetchLevelCaches(LevelParams, Levels, Cache);
+    FetchLevelCaches(LevelParams, Levels, Cache, !Persistent);
 
     uint32_t nParams = 0;
     for (auto Level : Levels)


### PR DESCRIPTION
[RSP-356](https://d3technologies.atlassian.net/browse/RSP-356)

**Technical Description:**
Exposed parameters didn't work when adding another exposed parameter to a sublevel while UE project is on Maps Scene Selector mode. The main problem was with failing  `ValidateParameters` function that caused not calling `ApplyParameters`. I noticed that `ValidateParameters` was failing because JSON provided more parameters than we expected. 

Another issue was with text parameters values worked only for the 1st text param, but not for 2nd+ ones. That happened because we didn't have an internal count and we were always reading the 0 value.

**Resolution Details:**
The main issue was with the way we generated the JSON file for different Scene Selectors. I changed it, so now it happens according to the following table:
| Scene Selector | Persistent Level | Sublevel |
| ------------- | ------------- | ------------- |
| None  | Parameters from all levels  | X  |
| Maps  | Persistent level's parameters only  | Sublevel's parameters only |
| Streaming Level | Persistent level's parameters only  | Persistent level's + Sublevel's parameters |

Source: https://help.disguise.one/workflows/renderstream/unreal-engine/scene-levels (which is imo a bit confusing and should be updated as well)

For the text parameters issue, I added a count similar to the ones we have for floats and images.

[RSP-356]: https://d3technologies.atlassian.net/browse/RSP-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ