### PR TITLE
Post Processing Settings Being Applied To The Wrong Camera

### DIFF
--- a/Source/RenderStream/Private/RenderStreamViewportClient.cpp
+++ b/Source/RenderStream/Private/RenderStreamViewportClient.cpp
@@ -1,7 +1,6 @@
 #include "RenderStreamViewportClient.h"
 
 #include "Camera/CameraActor.h"
-#include "RenderStreamChannelDefinition.h"
 #include "RenderStreamProjectionPolicy.h"
 #include "Render/Device/IDisplayClusterRenderDevice.h"
 #include "IDisplayCluster.h"
@@ -569,6 +568,14 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
 					if (PolicyController)
 						LocalPlayer = PolicyController->GetLocalPlayer();
 				}
+
+                const ACameraActor* Camera = Info.Template.Get();
+                const URenderStreamChannelDefinition* Definition = Camera ? Camera->FindComponentByClass<URenderStreamChannelDefinition>() : nullptr;
+
+                if (Definition != nullptr)
+                {
+                    ViewFamily.EngineShowFlags = Definition->ShowFlags;
+                }
 				/// !!!! disguise customizations
 
 				// Calculate the player's view information.
@@ -589,7 +596,7 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
 					Views.Add(View);
 
 					/// !!!! disguise customizations
-					UpdateView(&ViewFamily, View, Info);
+					UpdateView(&ViewFamily, View, Info, Definition);
 					/// !!!! disguise customizations
 
 					// Apply viewport context settings to view (crossGPU, visibility, etc)
@@ -1008,18 +1015,15 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
 
 /// DisplayClusterViewportClient.cpp copy-pasta
 
-void URenderStreamViewportClient::UpdateView(FSceneViewFamily* ViewFamily, FSceneView* View, const FRenderStreamViewportInfo& Info)
+void URenderStreamViewportClient::UpdateView(FSceneViewFamily* ViewFamily, FSceneView* View, const FRenderStreamViewportInfo& Info, const URenderStreamChannelDefinition* Definition)
 {
     if (!Info.Template.IsValid())
         return;
 
     TSet<FPrimitiveComponentId> Collection;
-    const ACameraActor* Camera = Info.Template.Get();
-    const URenderStreamChannelDefinition* Definition = Camera ? Camera->FindComponentByClass<URenderStreamChannelDefinition>() : nullptr;
+
     if (Definition != nullptr)
     {
-        EngineShowFlags = Definition->ShowFlags;
-        ViewFamily->EngineShowFlags = Definition->ShowFlags;
         View->bCameraMotionBlur = Definition->ShowFlags.MotionBlur;
         const TSet<TSoftObjectPtr<AActor>> Actors = Definition->DefaultVisibility == EChannelVisibilty::Visible ? Definition->Hidden : Definition->Visible;
         for (const TSoftObjectPtr<AActor> Actor : Actors)

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v1"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v4"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamViewportClient.h
+++ b/Source/RenderStream/Public/RenderStreamViewportClient.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "DisplayClusterViewportClient.h"
+#include "RenderStreamChannelDefinition.h"
 #include "RenderStreamViewportClient.generated.h"
 
 UCLASS()
@@ -18,7 +19,7 @@ public:
     virtual void Draw(FViewport* Viewport, FCanvas* SceneCanvas) override;
 
 protected:
-    void UpdateView(class FSceneViewFamily* ViewFamily, class FSceneView* View, const struct FRenderStreamViewportInfo& Info);
+    void UpdateView(class FSceneViewFamily* ViewFamily, class FSceneView* View, const struct FRenderStreamViewportInfo& Info, const URenderStreamChannelDefinition* Definition);
 
 //#if WITH_EDITOR
 //    bool Draw_PIE(FViewport* InViewport, FCanvas* SceneCanvas);


### PR DESCRIPTION
Technical Description

In a scene with 2 cameras and different post processing setting, when using both of those cameras within the same layer the settings seem to be swapped between the cameras. The workaround is to have each camera as a single layer but this hurts performance. This solution fixes the issue by making sure the settings are being applied to the current camera before everything is submitted for rendering.