### PR TITLE
RSP-345: Camera focus does not work in UE 5.4

### DIFF
--- a/Source/RenderStream/Private/RenderStreamProjectionPolicy.cpp
+++ b/Source/RenderStream/Private/RenderStreamProjectionPolicy.cpp
@@ -7,6 +7,7 @@
 #include "Render/Viewport/IDisplayClusterViewportProxy.h"
 #include "Config/IDisplayClusterConfigManager.h"
 #include "DisplayClusterConfigurationTypes.h"
+#include "DisplayCluster/Public/DisplayClusterRootActor.h"
 
 #include "Camera/CameraActor.h"
 #include "Camera/CameraComponent.h"
@@ -155,6 +156,60 @@ bool FRenderStreamProjectionPolicy::GetProjectionMatrix(class IDisplayClusterVie
     OutPrjMatrix = PrjMatrix * clippingMatrix;
 
     return true;
+}
+
+bool FRenderStreamProjectionPolicy::ImplSetupProjectionViewPoint(IDisplayClusterViewport* InViewport, const float InDeltaTime, FMinimalViewInfo& InOutViewInfo, float* OutCustomNearClippingPlane) const
+{
+	if (OutCustomNearClippingPlane)
+	{
+		*OutCustomNearClippingPlane = -1;
+	}
+
+	bool bResult = false;
+
+    FRenderStreamModule* Module = FRenderStreamModule::Get();
+    check(Module);
+    auto& Info = Module->GetViewportInfo(InViewport->GetId());
+    UCameraComponent* AssignedCamera = Info.Camera.IsValid() ? Info.Camera->GetCameraComponent() : nullptr;
+
+	constexpr bool UseCameraPostProcess = true;
+
+	if (AssignedCamera)
+	{
+		// Use assigned camera component
+		// Store CustomNearClippingPlane locally, and then use that value for the projection matrix
+		bResult = IDisplayClusterViewport::GetCameraComponentView(AssignedCamera, InDeltaTime, UseCameraPostProcess, InOutViewInfo, OutCustomNearClippingPlane);
+	}
+	else if (UWorld* CurrentWorld = InViewport ? InViewport->GetConfiguration().GetCurrentWorld() : nullptr)
+	{
+		// Get active player camera
+		bResult = IDisplayClusterViewport::GetPlayerCameraView(CurrentWorld, UseCameraPostProcess, InOutViewInfo);
+	}
+
+	// Fix camera lens deffects (prototype)
+	// InOutViewInfo.Location += CameraSettings.FrustumOffset;
+	// InOutViewInfo.Rotation += CameraSettings.FrustumRotation;
+
+	return bResult;
+}
+
+void FRenderStreamProjectionPolicy::UpdatePostProcessSettings(IDisplayClusterViewport* InViewport)
+{
+    // Copied from FDisplayClusterProjectionCameraPolicy
+	if (InViewport && !EnumHasAnyFlags(InViewport->GetRenderSettingsICVFX().RuntimeFlags, EDisplayClusterViewportRuntimeICVFXFlags::InCamera))
+	{
+		float DeltaTime = 0.0f;
+		if (ADisplayClusterRootActor* SceneRootActor = InViewport->GetConfiguration().GetRootActor(EDisplayClusterRootActorType::Scene))
+		{
+			DeltaTime = SceneRootActor->GetWorldDeltaSeconds();
+		}
+
+		FMinimalViewInfo ViewInfo;
+		if (ImplSetupProjectionViewPoint(InViewport, DeltaTime, ViewInfo) && ViewInfo.PostProcessBlendWeight > 0.0f)
+		{
+			InViewport->GetViewport_CustomPostProcessSettings().AddCustomPostProcess(IDisplayClusterViewport_CustomPostProcessSettings::ERenderPass::Override, ViewInfo.PostProcessSettings, ViewInfo.PostProcessBlendWeight, true);
+		}
+	}
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/RenderStream/Public/RenderStreamProjectionPolicy.h
+++ b/Source/RenderStream/Public/RenderStreamProjectionPolicy.h
@@ -37,6 +37,10 @@ public:
     
     bool CalculateView(class IDisplayClusterViewport* InViewport, const uint32 InContextNum, FVector& InOutViewLocation, FRotator& InOutViewRotation, const FVector& ViewOffset, const float WorldToMeters, const float NCP, const float FCP) override;
     bool GetProjectionMatrix(class IDisplayClusterViewport* InViewport, const uint32 InContextNum, FMatrix& OutPrjMatrix) override;
+
+	// Override post-processing
+	// Required since UE5.4 in order to enable camera post-processing effects such as depth of field
+	virtual void UpdatePostProcessSettings(IDisplayClusterViewport* InViewport) override; 
     
     const TMap<FString, FString>& GetParameters() const
     {
@@ -44,6 +48,8 @@ public:
     }
     
 protected:
+    bool ImplSetupProjectionViewPoint(IDisplayClusterViewport* InViewport, const float InDeltaTime, FMinimalViewInfo& InOutViewInfo, float* OutCustomNearClippingPlane = nullptr) const;
+
     FString ProjectionPolicyId;
     TMap<FString, FString> Parameters;
     


### PR DESCRIPTION
## Technical Description:
UE 5.4 implements new ICVFX features which mean that the nDisplay viewports and projections code has changed in regards to post-processing.
An example can be seen in the nDisplay camera projection code where camera post-processing parameters are set on every viewport in a new virtual function called `UpdatePostProcessSettings`.
The RenderStream projection policy does not override that function so it must be using default post processing settings.

## Resolution Details:
I have implemented the `UpdatePostProcessSettings` function similarly to how it is implemented in `FDisplayClusterProjectionCameraPolicy`. In the case of RenderStream, I have enabled camera post-processing by default.