### PR TITLE
add working colour space support (version upgrade to RS2.1-UE5.3-v0)

### DIFF
--- a/CHANGELOG_UE5.3.md
+++ b/CHANGELOG_UE5.3.md
@@ -1,3 +1,7 @@
+# RS3.0-UE5.3-v0
+Compatible with disguise designer version r30.9 and above.
+* Add working colour space in schema
+
 # RS2.0-UE5.3-v2
 Compatible with disguise designer version r25.0 and above.
 * Fix for skeleton joint offsets not being applied in correct direction

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -2,6 +2,7 @@
 #include "RenderStream.h"
 
 #include "RenderStreamSettings.h"
+#include "Engine/RendererSettings.h"
 
 #if defined WIN32 || defined WIN64
 #define WINDOWS
@@ -27,7 +28,7 @@ namespace {
     }
 }
 
-const char* RenderStreamLink::ParamTypeToName(RemoteParameterType type)
+/*static*/ const char* RenderStreamLink::ParamTypeToName(RemoteParameterType type)
 {
     static const char* ParamTypeName[] = {
         "Number",
@@ -43,6 +44,26 @@ const char* RenderStreamLink::ParamTypeToName(RemoteParameterType type)
     return ParamTypeName[type];
 }
 
+/*static*/ RenderStreamLink::RSColourSpace RenderStreamLink::GetWorkingColourSpace()
+{
+    switch (GetDefault<URendererSettings>()->WorkingColorSpaceChoice.GetValue())
+    {
+    case EWorkingColorSpace::Type::sRGB:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_sRGB;
+    case EWorkingColorSpace::Type::Rec2020:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_Rec2020;
+    case EWorkingColorSpace::Type::ACESAP0:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_ACES2065;
+    case EWorkingColorSpace::Type::ACESAP1:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_ACEScg;
+    case EWorkingColorSpace::Type::P3D65:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_P3D65;
+    case EWorkingColorSpace::Type::P3DCI:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_P3DCI;
+    default:
+        return RenderStreamLink::RSColourSpace::RS_COLOUR_SPACE_UNKNOWN;
+    }
+}
 
 /*static*/ RenderStreamLink& RenderStreamLink::instance()
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v2"
+#define RS_PLUGIN_VERSION "RS3.0-UE5.3-v0"
 
 class RenderStreamLink
 {
@@ -254,6 +254,7 @@ public:
         RS_PARAMETER_SKELETON,
         RS_PARAMETER_LAST= RS_PARAMETER_SKELETON
     };
+    static const char* ParamTypeToName(RemoteParameterType type);
 
     enum RemoteParameterDmxType
     {
@@ -261,8 +262,18 @@ public:
         RS_DMX_8,
         RS_DMX_16_BE,
     };
-
-    static const char* ParamTypeToName(RemoteParameterType type);
+    
+    enum RSColourSpace
+    {
+        RS_COLOUR_SPACE_UNKNOWN,
+        RS_COLOUR_SPACE_sRGB,
+        RS_COLOUR_SPACE_Rec2020,
+        RS_COLOUR_SPACE_ACES2065,
+        RS_COLOUR_SPACE_ACEScg,
+        RS_COLOUR_SPACE_P3D65,
+        RS_COLOUR_SPACE_P3DCI,
+    };
+    RENDERSTREAM_API static RSColourSpace GetWorkingColourSpace();
 
     typedef struct
     {
@@ -331,6 +342,7 @@ public:
         const char* engineVersion;
         const char* pluginVersion;
         const char* info;
+        RSColourSpace workingColourSpace;
         Channels channels;
         Scenes scenes;
     } Schema;
@@ -343,7 +355,7 @@ public:
 
 #pragma pack(pop)
 
-#define RENDER_STREAM_VERSION_MAJOR 2
+#define RENDER_STREAM_VERSION_MAJOR 3
 #define RENDER_STREAM_VERSION_MINOR 0
 
     enum UseDX12SharedHeapFlag
@@ -499,6 +511,7 @@ public:
             schema.engineVersion = _strdup(TCHAR_TO_UTF8(ENGINE_VERSION_STRING));
             schema.pluginVersion = _strdup(RS_PLUGIN_VERSION);
             schema.info = _strdup(TCHAR_TO_UTF8(*GetDefault<UGeneralProjectSettings>()->Description));
+            schema.workingColourSpace = GetWorkingColourSpace();
             schema.channels.nChannels = 0;
             schema.channels.channels = nullptr;
             schema.scenes.nScenes = 0;

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -31,6 +31,7 @@
 
 #include "Runtime/Launch/Resources/Version.h"
 #include "GeneralProjectSettings.h"
+#include "Engine/RendererSettings.h"
 
 #include "RenderStream/Public/RenderStreamLink.h"
 #include <set>
@@ -742,6 +743,7 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
     Schema.schema.engineVersion = _strdup(TCHAR_TO_UTF8(ENGINE_VERSION_STRING));
     Schema.schema.pluginVersion = _strdup(RS_PLUGIN_VERSION);
     Schema.schema.info = _strdup(TCHAR_TO_UTF8(*GetDefault<UGeneralProjectSettings>()->Description));
+    Schema.schema.workingColourSpace = RenderStreamLink::GetWorkingColourSpace();
     Schema.schema.channels.nChannels = uint32_t(Channels.size());
     Schema.schema.channels.channels = static_cast<const char**>(malloc(Schema.schema.channels.nChannels * sizeof(const char*)));
     auto It = Channels.begin();


### PR DESCRIPTION
# Add RS working colour space support

> RST-353

## Linked PR

- https://github.com/disguise-one/d3/pull/3169

## Summary

Designer must aware of Unreal Engine’s working colour space when implementing texture sharing. Because texture sharing is bypassed until the end of UE’s rendering pipeline, Designer needs to account for the UE working colour space, so when colour transform (Transform Source -> Transform Destination) is applied, texture sharing texture also can produce a correct colour. Adding a new `workingColourSpace` field in the Schema for this.

Note that this also include the minor version update from `RS2.0` to `RS2.1`