### PR TITLE
5.6 Update

### DIFF
--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -7,7 +7,6 @@
 #include "D3D12RHIBridge.h"
 
 #include "VulkanRHIPrivate.h"
-#include "VulkanRHIBridge.h"
 #include "VulkanResources.h"
 
 #include "Windows/AllowWindowsPlatformTypes.h"

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -76,7 +76,6 @@
 #include <ID3D12DynamicRHI.h>
 
 #include "VulkanRHIPrivate.h"
-#include "VulkanRHIBridge.h"
 #include "VulkanResources.h"
 
 DEFINE_LOG_CATEGORY(LogRenderStream);

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -687,6 +687,10 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     RenderStreamLink::SenderFrame data = {};
                     if (toggle == "D3D11")
                     {
+                        {
+                            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
+                            RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
+                        }
                         data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX11_TEXTURE;
                         data.dx11.resource = static_cast<ID3D11Resource*>(resource);
                         auto err = RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data);

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -18,7 +18,6 @@
 #include "UObject/TextProperty.h"
 
 #include "VulkanRHIPrivate.h"
-#include "VulkanRHIBridge.h"
 #include "VulkanResources.h"
 
 #include "HardwareInfo.h"

--- a/Source/RenderStream/Private/RenderStreamViewportClient.cpp
+++ b/Source/RenderStream/Private/RenderStreamViewportClient.cpp
@@ -67,6 +67,57 @@
 #include "UObject/UObjectGlobals.h"
 #include "UObject/Package.h"
 
+// Debug feature to synchronize and force all external resources to be transferred cross GPU at the end of graph execution.
+// May be useful for testing cross GPU synchronization logic.
+int32 GDisplayClusterForceCopyCrossGPU = 0;
+static FAutoConsoleVariableRef CVarDisplayClusterForceCopyCrossGPU(
+    TEXT("DC.ForceCopyCrossGPU"),
+    GDisplayClusterForceCopyCrossGPU,
+    TEXT("Force cross GPU copy of all resources after each view render.  Bad for perf, but may be useful for debugging."),
+    ECVF_RenderThreadSafe
+);
+
+int32 GDisplayClusterShowStats = 0;
+static FAutoConsoleVariableRef CVarDisplayClusterShowStats(
+    TEXT("DC.Stats"),
+    GDisplayClusterShowStats,
+    TEXT("Show per-view profiling stats for display cluster rendering."),
+    ECVF_RenderThreadSafe
+);
+
+int32 GDisplayClusterSingleRender = 1;
+static FAutoConsoleVariableRef CVarDisplayClusterSingleRender(
+    TEXT("DC.SingleRender"),
+    GDisplayClusterSingleRender,
+    TEXT("Render Display Cluster view families in a single scene render."),
+    ECVF_RenderThreadSafe
+);
+
+int32 GDisplayClusterSortViews = 1;
+static FAutoConsoleVariableRef CVarDisplayClusterSortViews(
+    TEXT("DC.SortViews"),
+    GDisplayClusterSortViews,
+    TEXT("Enable sorting of views by decreasing pixel count and decreasing GPU index.  Adds determinism, and tends to run inners first, which helps with scheduling, improving perf (default: enabled)."),
+    ECVF_RenderThreadSafe
+);
+
+int32 GDisplayClusterDebugDraw = 1;
+static FAutoConsoleVariableRef CVarDisplayClusterDebugDraw(
+    TEXT("DC.DebugDraw"),
+    GDisplayClusterDebugDraw,
+    TEXT("Enable debug draw for nDisplay views.  Debug draw features are separately enabled, and default to off, this just provides an additional global toggle."),
+    ECVF_RenderThreadSafe
+);
+
+// Replaces FApp::HasFocus
+bool GDisplayClusterReplaceHasFocusFunction = true;
+static FAutoConsoleVariableRef CVarDisplayClusterReplaceHasFocusFunction(
+    TEXT("DC.ReplaceHasFocusFunction"),
+    GDisplayClusterReplaceHasFocusFunction,
+    TEXT("Replaces the function that FApp::HasFocus() uses, to mitigate OS stalls that happen in some systems."),
+    ECVF_ReadOnly
+);
+
 URenderStreamViewportClient::URenderStreamViewportClient(FVTableHelper& Helper)
     : Super(Helper)
 {
@@ -105,46 +156,47 @@ void URenderStreamViewportClient::Init(struct FWorldContext& WorldContext, UGame
     /// !!!! disguise customizations
     if (bIsNDisplayClusterMode)
 	{
-		// r.CompositionForceRenderTargetLoad
-		IConsoleVariable* const MaxTextureDimension = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.OverrideMaxTextureDimension"));
-		if (MaxTextureDimension)
-		{
-			MaxTextureDimension->Set(int32(16384));
-		}
+        // r.CompositionForceRenderTargetLoad
+        IConsoleVariable* const ForceLoadCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.CompositionForceRenderTargetLoad"));
+        if (ForceLoadCVar)
+        {
+            ForceLoadCVar->Set(int32(1));
+        }
 
-		IConsoleVariable* const ForceLoadCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.CompositionForceRenderTargetLoad"));
-		if (ForceLoadCVar)
-		{
-			ForceLoadCVar->Set(int32(1));
-		}
+        // r.SceneRenderTargetResizeMethodForceOverride
+        IConsoleVariable* const RTResizeForceOverrideCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.SceneRenderTargetResizeMethodForceOverride"));
+        if (RTResizeForceOverrideCVar)
+        {
+            RTResizeForceOverrideCVar->Set(int32(1));
+        }
 
-		// r.SceneRenderTargetResizeMethodForceOverride
-		IConsoleVariable* const RTResizeForceOverrideCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.SceneRenderTargetResizeMethodForceOverride"));
-		if (RTResizeForceOverrideCVar)
-		{
-			RTResizeForceOverrideCVar->Set(int32(1));
-		}
+        // r.SceneRenderTargetResizeMethod
+        IConsoleVariable* const RTResizeCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.SceneRenderTargetResizeMethod"));
+        if (RTResizeCVar)
+        {
+            RTResizeCVar->Set(int32(2));
+        }
 
-		// r.SceneRenderTargetResizeMethod
-		IConsoleVariable* const RTResizeCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("r.SceneRenderTargetResizeMethod"));
-		if (RTResizeCVar)
-		{
-			RTResizeCVar->Set(int32(2));
-		}
+        // RHI.MaximumFrameLatency
+        IConsoleVariable* const MaximumFrameLatencyCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("RHI.MaximumFrameLatency"));
+        if (MaximumFrameLatencyCVar)
+        {
+            MaximumFrameLatencyCVar->Set(int32(1));
+        }
 
-		// RHI.MaximumFrameLatency
-		IConsoleVariable* const MaximumFrameLatencyCVar = IConsoleManager::Get().FindConsoleVariable(TEXT("RHI.MaximumFrameLatency"));
-		if (MaximumFrameLatencyCVar)
-		{
-			MaximumFrameLatencyCVar->Set(int32(1));
-		}
+        // vr.AllowMotionBlurInVR
+        IConsoleVariable* const AllowMotionBlurInVR = IConsoleManager::Get().FindConsoleVariable(TEXT("vr.AllowMotionBlurInVR"));
+        if (AllowMotionBlurInVR)
+        {
+            AllowMotionBlurInVR->Set(int32(1));
+        }
 
-		// vr.AllowMotionBlurInVR
-		IConsoleVariable* const AllowMotionBlurInVR = IConsoleManager::Get().FindConsoleVariable(TEXT("vr.AllowMotionBlurInVR"));
-		if (AllowMotionBlurInVR)
-		{
-			AllowMotionBlurInVR->Set(int32(1));
-		}
+        // Replace FApp::HasFocus to avoid stalls observed in some render nodes. 
+        // It always return true, so all code behaves as if the application were in focus, even when rendering offscreen.
+        if (GDisplayClusterReplaceHasFocusFunction)
+        {
+            FApp::SetHasFocusFunction([]() { return true; });
+        }
 	}
 
 	Super::Init(WorldContext, OwningGameInstance, bCreateNewAudioDevice);
@@ -376,636 +428,525 @@ private:
 
 void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanvas)
 {
-	/// !!!! disguise customizations
-	static const auto DisplayClusterForceCopyCrossGPU = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.ForceCopyCrossGPU"));
-	static const auto DisplayClusterLumenPerView = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.LumenPerView"));
-	static const auto DisplayClusterSortViews = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SortViews"));
-	static const auto DisplayClusterSingleRender = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SingleRender"));
-	static const auto DisplayClusterDebugDraw = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.DebugDraw"));
-	/// !!!! disguise customizations
+    /// !!!! disguise customizations
+    static const auto DisplayClusterForceCopyCrossGPU = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.ForceCopyCrossGPU"));
+    static const auto DisplayClusterLumenPerView = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.LumenPerView"));
+    static const auto DisplayClusterSortViews = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SortViews"));
+    static const auto DisplayClusterSingleRender = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SingleRender"));
+    static const auto DisplayClusterDebugDraw = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.DebugDraw"));
+    /// !!!! disguise customizations
 
-	////////////////////////////////
-	// For any operation mode other than 'Cluster' we use default UGameViewportClient::Draw pipeline
-	/// !!!! disguise customizations - we must always use this method.
-	const bool bIsNDisplayClusterMode = true; //(GEngine->StereoRenderingDevice.IsValid() && GDisplayCluster->GetOperationMode() == EDisplayClusterOperationMode::Cluster);
-	/// !!!! disguise customizations
+    ////////////////////////////////
+    // For any operation mode other than 'Cluster' we use default UGameViewportClient::Draw pipeline
+    /// !!!! disguise customizations - we must always use this method.
+    const bool bIsNDisplayClusterMode = true; //(GEngine->StereoRenderingDevice.IsValid() && GDisplayCluster->GetOperationMode() == EDisplayClusterOperationMode::Cluster);
+    /// !!!! disguise customizations
 
-	// Get nDisplay stereo device
-	IDisplayClusterRenderDevice* const DCRenderDevice = bIsNDisplayClusterMode ? static_cast<IDisplayClusterRenderDevice* const>(GEngine->StereoRenderingDevice.Get()) : nullptr;
+    // Get nDisplay stereo device
+    IDisplayClusterRenderDevice* const DCRenderDevice = bIsNDisplayClusterMode ? static_cast<IDisplayClusterRenderDevice* const>(GEngine->StereoRenderingDevice.Get()) : nullptr;
 
-	if (!bIsNDisplayClusterMode || DCRenderDevice == nullptr)
-	{
+    if (!bIsNDisplayClusterMode || DCRenderDevice == nullptr)
+    {
 #if WITH_EDITOR
-		// Special render for PIE
-		if (!IsRunningGame() && Draw_PIE(InViewport, SceneCanvas))
-		{
-			return;
-		}
+        // Special render for PIE
+        if (!IsRunningGame() && Draw_PIE(InViewport, SceneCanvas))
+        {
+            return;
+        }
 #endif
-		return UGameViewportClient::Draw(InViewport, SceneCanvas);
-	}
+        return UGameViewportClient::Draw(InViewport, SceneCanvas);
+    }
 
-	//Get world for render
-	UWorld* const MyWorld = GetWorld();
+    //Get world for render
+    UWorld* const MyWorld = GetWorld();
 
-	////////////////////////////////
-	// Otherwise we use our own version of the UGameViewportClient::Draw which is basically
-	// a simpler version of the original one but with multiple ViewFamilies support
+    ////////////////////////////////
+    // Otherwise we use our own version of the UGameViewportClient::Draw which is basically
+    // a simpler version of the original one but with multiple ViewFamilies support
 
-	// Valid SceneCanvas is required.  Make this explicit.
-	check(SceneCanvas);
+    // Valid SceneCanvas is required.  Make this explicit.
+    check(SceneCanvas);
 
-	OnBeginDraw().Broadcast();
+    OnBeginDraw().Broadcast();
 
-	const bool bStereoRendering = GEngine->IsStereoscopic3D(InViewport);
-	FCanvas* DebugCanvas = InViewport->GetDebugCanvas();
+    const bool bStereoRendering = GEngine->IsStereoscopic3D(InViewport);
+    FCanvas* DebugCanvas = InViewport->GetDebugCanvas();
 
-	// Create a temporary canvas if there isn't already one.
-	static FName CanvasObjectName(TEXT("CanvasObject"));
-	UCanvas* CanvasObject = GetCanvasByName(CanvasObjectName);
-	CanvasObject->Canvas = SceneCanvas;
+    // Create a temporary canvas if there isn't already one.
+    static FName CanvasObjectName(TEXT("CanvasObject"));
+    UCanvas* CanvasObject = GetCanvasByName(CanvasObjectName);
+    CanvasObject->Canvas = SceneCanvas;
 
-	// Create temp debug canvas object
-	FIntPoint DebugCanvasSize = InViewport->GetSizeXY();
-	if (bStereoRendering && GEngine->XRSystem.IsValid() && GEngine->XRSystem->GetHMDDevice())
-	{
-		DebugCanvasSize = GEngine->XRSystem->GetHMDDevice()->GetIdealDebugCanvasRenderTargetSize();
-	}
+    // Create temp debug canvas object
+    FIntPoint DebugCanvasSize = InViewport->GetSizeXY();
+    if (bStereoRendering && GEngine->XRSystem.IsValid() && GEngine->XRSystem->GetHMDDevice())
+    {
+        DebugCanvasSize = GEngine->XRSystem->GetHMDDevice()->GetIdealDebugCanvasRenderTargetSize();
+    }
 
-	static FName DebugCanvasObjectName(TEXT("DebugCanvasObject"));
-	UCanvas* DebugCanvasObject = GetCanvasByName(DebugCanvasObjectName);
-	DebugCanvasObject->Init(DebugCanvasSize.X, DebugCanvasSize.Y, NULL, DebugCanvas);
+    static FName DebugCanvasObjectName(TEXT("DebugCanvasObject"));
+    UCanvas* DebugCanvasObject = GetCanvasByName(DebugCanvasObjectName);
+    DebugCanvasObject->Init(DebugCanvasSize.X, DebugCanvasSize.Y, NULL, DebugCanvas);
 
-	if (DebugCanvas)
-	{
-		DebugCanvas->SetScaledToRenderTarget(bStereoRendering);
-		DebugCanvas->SetStereoRendering(bStereoRendering);
-	}
-	if (SceneCanvas)
-	{
-		SceneCanvas->SetScaledToRenderTarget(bStereoRendering);
-		SceneCanvas->SetStereoRendering(bStereoRendering);
-	}
+    if (DebugCanvas)
+    {
+        DebugCanvas->SetScaledToRenderTarget(bStereoRendering);
+        DebugCanvas->SetStereoRendering(bStereoRendering);
+    }
+    if (SceneCanvas)
+    {
+        SceneCanvas->SetScaledToRenderTarget(bStereoRendering);
+        SceneCanvas->SetStereoRendering(bStereoRendering);
+    }
 
-	// Force path tracing view mode, and extern code set path tracer show flags
-	const bool bForcePathTracing = InViewport->GetClient()->GetEngineShowFlags()->PathTracing;
-	if (bForcePathTracing)
-	{
-		EngineShowFlags.SetPathTracing(true);
-		ViewModeIndex = VMI_PathTracing;
-	}
+    // Force path tracing view mode, and extern code set path tracer show flags
+    const bool bForcePathTracing = InViewport->GetClient()->GetEngineShowFlags()->PathTracing;
+    if (bForcePathTracing)
+    {
+        EngineShowFlags.SetPathTracing(true);
+        ViewModeIndex = VMI_PathTracing;
+    }
 
-	APlayerController* const PlayerController = GEngine->GetFirstLocalPlayerController(GetWorld());
-	ULocalPlayer* LocalPlayer = nullptr;
-	if (PlayerController)
-	{
-		LocalPlayer = PlayerController->GetLocalPlayer();
-	}
+    APlayerController* const PlayerController = GEngine->GetFirstLocalPlayerController(GetWorld());
+    ULocalPlayer* LocalPlayer = nullptr;
+    if (PlayerController)
+    {
+        LocalPlayer = PlayerController->GetLocalPlayer();
+    }
 
-	if (!PlayerController || !LocalPlayer)
-	{
-		return Super::Draw(InViewport, SceneCanvas);
-	}
+    if (!PlayerController || !LocalPlayer)
+    {
+        return Super::Draw(InViewport, SceneCanvas);
+    }
 
-	// Gather all view families first
-	TArray<FSceneViewFamilyContext*> ViewFamilies;
+    // Gather all view families first
+    TArray<FSceneViewFamilyContext*> ViewFamilies;
 
-	// Initialize new render frame resources
-	FDisplayClusterRenderFrame RenderFrame;
-	if (!DCRenderDevice->BeginNewFrame(InViewport, MyWorld, RenderFrame))
-	{
-		// skip rendering: Can't build render frame
-		return;
-	}
+    // Initialize new render frame resources
+    FDisplayClusterRenderFrame RenderFrame;
+    if (!DCRenderDevice->BeginNewFrame(InViewport, MyWorld, RenderFrame))
+    {
+        // skip rendering: Can't build render frame
+        return;
+    }
 
-	IDisplayClusterViewportManager* RenderFrameViewportManager = RenderFrame.GetViewportManager();
-	if (!RenderFrameViewportManager)
-	{
-		// skip rendering: Can't find render manager
-		return;
-	}
+    IDisplayClusterViewportManager* RenderFrameViewportManager = RenderFrame.GetViewportManager();
+    if (!RenderFrameViewportManager)
+    {
+        // skip rendering: Can't find render manager
+        return;
+    }
 
-	// Handle special viewports game-thread logic at frame begin
-	DCRenderDevice->InitializeNewFrame();
+    // Handle special viewports game-thread logic at frame begin
+    DCRenderDevice->InitializeNewFrame();
 
-	for (FDisplayClusterRenderFrameTarget& DCRenderTarget : RenderFrame.RenderTargets)
-	{
-		for (FDisplayClusterRenderFrameTargetViewFamily& DCViewFamily : DCRenderTarget.ViewFamilies)
-		{
-			// Create the view family for rendering the world scene to the viewport's render target
-			ViewFamilies.Add(new FSceneViewFamilyContext(RenderFrameViewportManager->CreateViewFamilyConstructionValues(
-				DCRenderTarget,
-				MyWorld->Scene,
-				EngineShowFlags,
-				false				// bAdditionalViewFamily  (filled in later, after list of families is known, and optionally reordered)
-			)));
-			FSceneViewFamilyContext& ViewFamily = *ViewFamilies.Last();
-			bool bIsFamilyVisible = false;
+    for (FDisplayClusterRenderFrameTarget& DCRenderTarget : RenderFrame.RenderTargets)
+    {
+        for (FDisplayClusterRenderFrameTargetViewFamily& DCViewFamily : DCRenderTarget.ViewFamilies)
+        {
+            // Create the view family for rendering the world scene to the viewport's render target
+            ViewFamilies.Add(new FSceneViewFamilyContext(RenderFrameViewportManager->CreateViewFamilyConstructionValues(
+                DCRenderTarget,
+                MyWorld->Scene,
+                EngineShowFlags,
+                false				// bAdditionalViewFamily  (filled in later, after list of families is known, and optionally reordered)
+            )));
+            FSceneViewFamilyContext& ViewFamily = *ViewFamilies.Last();
+            bool bIsFamilyVisible = false;
 
-			// Configure family
-			RenderFrameViewportManager->ConfigureViewFamily(DCRenderTarget, DCViewFamily, ViewFamily);
+            // Configure family for the nDisplay.
+            RenderFrameViewportManager->ConfigureViewFamily(DCRenderTarget, DCViewFamily, ViewFamily);
 
-#if WITH_EDITOR
-			if (GIsEditor)
-			{
-				// Force enable view family show flag for HighDPI derived's screen percentage.
-				ViewFamily.EngineShowFlags.ScreenPercentage = true;
-			}
+            ViewFamily.ViewMode = EViewModeIndex(ViewModeIndex);
+            EngineShowFlagOverride(ESFIM_Game, ViewFamily.ViewMode, ViewFamily.EngineShowFlags, false);
+
+            if (ViewFamily.EngineShowFlags.VisualizeBuffer && AllowDebugViewmodes())
+            {
+                // Process the buffer visualization console command
+                FName NewBufferVisualizationMode = NAME_None;
+                static IConsoleVariable* ICVar = IConsoleManager::Get().FindConsoleVariable(FBufferVisualizationData::GetVisualizationTargetConsoleCommandName());
+                if (ICVar)
+                {
+                    static const FName OverviewName = TEXT("Overview");
+                    FString ModeNameString = ICVar->GetString();
+                    FName ModeName = *ModeNameString;
+                    if (ModeNameString.IsEmpty() || ModeName == OverviewName || ModeName == NAME_None)
+                    {
+                        NewBufferVisualizationMode = NAME_None;
+                    }
+                    else
+                    {
+                        if (GetBufferVisualizationData().GetMaterial(ModeName) == NULL)
+                        {
+                            // Mode is out of range, so display a message to the user, and reset the mode back to the previous valid one
+                            UE_LOG(LogConsoleResponse, Warning, TEXT("Buffer visualization mode '%s' does not exist"), *ModeNameString);
+                            NewBufferVisualizationMode = GetCurrentBufferVisualizationMode();
+                            // todo: cvars are user settings, here the cvar state is used to avoid log spam and to auto correct for the user (likely not what the user wants)
+                            ICVar->Set(*NewBufferVisualizationMode.GetPlainNameString(), ECVF_SetByCode);
+                        }
+                        else
+                        {
+                            NewBufferVisualizationMode = ModeName;
+                        }
+                    }
+                }
+
+                if (NewBufferVisualizationMode != GetCurrentBufferVisualizationMode())
+                {
+                    SetCurrentBufferVisualizationMode(NewBufferVisualizationMode);
+                }
+            }
+
+            TMap<ULocalPlayer*, FSceneView*> PlayerViewMap;
+            FAudioDeviceHandle RetrievedAudioDevice = MyWorld->GetAudioDevice();
+            TArray<FSceneView*> Views;
+
+            for (FDisplayClusterRenderFrameTargetView& DCView : DCViewFamily.Views)
+            {
+                const FDisplayClusterViewport_Context ViewportContext = DCView.Viewport->GetContexts()[DCView.ContextNum];
+
+                /// !!!! disguise customizations
+                auto& Info = FRenderStreamModule::Get()->GetViewportInfo(DCView.Viewport->GetId());
+                if (Info.PlayerId != -1)
+                {
+                    APlayerController* PolicyController = UGameplayStatics::GetPlayerControllerFromID(World, Info.PlayerId);
+                    if (PolicyController)
+                        LocalPlayer = PolicyController->GetLocalPlayer();
+                }
+                /// !!!! disguise customizations
+
+                // Calculate the player's view information.
+                FVector		ViewLocation;
+                FRotator	ViewRotation;
+                FSceneView* View = RenderFrameViewportManager->CalcSceneView(LocalPlayer, &ViewFamily, ViewLocation, ViewRotation, InViewport, nullptr, ViewportContext.StereoViewIndex);
+
+                if (View && (!DCView.IsViewportContextCanBeRendered() || ViewFamily.RenderTarget == nullptr))
+                {
+                    ViewFamily.Views.Remove(View);
+
+                    delete View;
+                    View = nullptr;
+                }
+
+                if (View)
+                {
+                    Views.Add(View);
+
+                    /// !!!! disguise customizations
+                    UpdateView(&ViewFamily, View, Info);
+                    /// !!!! disguise customizations
+
+                    // We don't allow instanced stereo currently
+                    View->bIsInstancedStereoEnabled = false;
+                    View->bShouldBindInstancedViewUB = false;
+
+
+                    if (View->Family->EngineShowFlags.Wireframe)
+                    {
+                        // Wireframe color is emissive-only, and mesh-modifying materials do not use material substitution, hence...
+                        View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                        View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                    }
+                    else if (View->Family->EngineShowFlags.OverrideDiffuseAndSpecular)
+                    {
+                        View->DiffuseOverrideParameter = FVector4f(GEngine->LightingOnlyBrightness.R, GEngine->LightingOnlyBrightness.G, GEngine->LightingOnlyBrightness.B, 0.0f);
+                        View->SpecularOverrideParameter = FVector4f(.1f, .1f, .1f, 0.0f);
+                    }
+                    else if (View->Family->EngineShowFlags.LightingOnlyOverride)
+                    {
+                        View->DiffuseOverrideParameter = FVector4f(GEngine->LightingOnlyBrightness.R, GEngine->LightingOnlyBrightness.G, GEngine->LightingOnlyBrightness.B, 0.0f);
+                        View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                    }
+                    else if (View->Family->EngineShowFlags.ReflectionOverride)
+                    {
+                        View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                        View->SpecularOverrideParameter = FVector4f(1, 1, 1, 0.0f);
+                        View->NormalOverrideParameter = FVector4f(0, 0, 1, 0.0f);
+                        View->RoughnessOverrideParameter = FVector2f(0.0f, 0.0f);
+                    }
+
+                    if (!View->Family->EngineShowFlags.Diffuse)
+                    {
+                        View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                    }
+
+                    if (!View->Family->EngineShowFlags.Specular)
+                    {
+                        View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
+                    }
+
+                    if (!View->Family->EngineShowFlags.MaterialNormal)
+                    {
+                        View->NormalOverrideParameter = FVector4f(0.0f, 0.0f, 1.0f, 0.0f);
+                    }
+
+                    if (!View->Family->EngineShowFlags.MaterialAmbientOcclusion)
+                    {
+                        View->AmbientOcclusionOverrideParameter = FVector2f(1.0f, 0.0f);
+                    }
+
+                    View->CurrentBufferVisualizationMode = GetCurrentBufferVisualizationMode();
+
+                    View->CameraConstrainedViewRect = View->UnscaledViewRect;
+
+
+
+                    {
+                        // Save the location of the view.
+                        LocalPlayer->LastViewLocation = ViewLocation;
+
+                        PlayerViewMap.Add(LocalPlayer, View);
+
+                        // Update the listener.
+                        if (RetrievedAudioDevice && PlayerController != NULL)
+                        {
+                            bool bUpdateListenerPosition = true;
+
+                            // If the main audio device is used for multiple PIE viewport clients, we only
+                            // want to update the main audio device listener position if it is in focus
+                            if (GEngine)
+                            {
+                                FAudioDeviceManager* AudioDeviceManager = GEngine->GetAudioDeviceManager();
+
+                                // If there is more than one world referencing the main audio device
+                                if (AudioDeviceManager->GetNumMainAudioDeviceWorlds() > 1)
+                                {
+                                    uint32 MainAudioDeviceID = GEngine->GetMainAudioDeviceID();
+                                    if (AudioDevice->DeviceID == MainAudioDeviceID && !HasAudioFocus())
+                                    {
+                                        bUpdateListenerPosition = false;
+                                    }
+                                }
+                            }
+
+                            if (bUpdateListenerPosition)
+                            {
+                                FVector Location;
+                                FVector ProjFront;
+                                FVector ProjRight;
+                                PlayerController->GetAudioListenerPosition(Location, ProjFront, ProjRight);
+
+                                FTransform ListenerTransform(FRotationMatrix::MakeFromXY(ProjFront, ProjRight));
+
+                                // Allow the HMD to adjust based on the head position of the player, as opposed to the view location
+                                if (GEngine->XRSystem.IsValid() && GEngine->StereoRenderingDevice.IsValid() && GEngine->StereoRenderingDevice->IsStereoEnabled())
+                                {
+                                    const FVector Offset = GEngine->XRSystem->GetAudioListenerOffset();
+                                    Location += ListenerTransform.TransformPositionNoScale(Offset);
+                                }
+
+                                ListenerTransform.SetTranslation(Location);
+                                ListenerTransform.NormalizeRotation();
+
+                                uint32 ViewportIndex = PlayerViewMap.Num() - 1;
+                                RetrievedAudioDevice->SetListener(MyWorld, ViewportIndex, ListenerTransform, (View->bCameraCut ? 0.f : MyWorld->GetDeltaSeconds()));
+
+                                FVector OverrideAttenuation;
+                                if (PlayerController->GetAudioListenerAttenuationOverridePosition(OverrideAttenuation))
+                                {
+                                    RetrievedAudioDevice->SetListenerAttenuationOverride(ViewportIndex, OverrideAttenuation);
+                                }
+                                else
+                                {
+                                    RetrievedAudioDevice->ClearListenerAttenuationOverride(ViewportIndex);
+                                }
+                            }
+                        }
+                    }
+
+                    // Add view information for resource streaming. Allow up to 5X boost for small FOV.
+                    const float StreamingScale = 1.f / FMath::Clamp<float>(View->LODDistanceFactor, .2f, 1.f);
+                    IStreamingManager::Get().AddViewInformation(View->ViewMatrices.GetViewOrigin(), View->UnscaledViewRect.Width(), View->UnscaledViewRect.Width() * View->ViewMatrices.GetProjectionMatrix().M[0][0], StreamingScale);
+                    MyWorld->ViewLocationsRenderedLastFrame.Add(View->ViewMatrices.GetViewOrigin());
+
+                    FWorldCachedViewInfo& WorldViewInfo = World->CachedViewInfoRenderedLastFrame.AddDefaulted_GetRef();
+                    WorldViewInfo.ViewMatrix = View->ViewMatrices.GetViewMatrix();
+                    WorldViewInfo.ProjectionMatrix = View->ViewMatrices.GetProjectionMatrix();
+                    WorldViewInfo.ViewProjectionMatrix = View->ViewMatrices.GetViewProjectionMatrix();
+                    WorldViewInfo.ViewToWorld = View->ViewMatrices.GetInvViewMatrix();
+                    World->LastRenderTime = World->GetTimeSeconds();
+                }
+            }
+
+#if CSV_PROFILER_STATS
+            UpdateCsvCameraStats(PlayerViewMap);
 #endif
+            if (ViewFamily.Views.Num() > 0)
+            {
+                FinalizeViews(&ViewFamily, PlayerViewMap);
 
-			ViewFamily.ViewMode = EViewModeIndex(ViewModeIndex);
-			EngineShowFlagOverride(ESFIM_Game, ViewFamily.ViewMode, ViewFamily.EngineShowFlags, false);
+                // Collect rendering flags for nDisplay:
+                EDisplayClusterViewportRenderingFlags ViewportRenderingFlags = EDisplayClusterViewportRenderingFlags::None;
+                if (bStereoRendering)
+                {
+                    EnumAddFlags(ViewportRenderingFlags, EDisplayClusterViewportRenderingFlags::StereoRendering);
+                }
 
-			if (ViewFamily.EngineShowFlags.VisualizeBuffer && AllowDebugViewmodes())
-			{
-				// Process the buffer visualization console command
-				FName NewBufferVisualizationMode = NAME_None;
-				static IConsoleVariable* ICVar = IConsoleManager::Get().FindConsoleVariable(FBufferVisualizationData::GetVisualizationTargetConsoleCommandName());
-				if (ICVar)
-				{
-					static const FName OverviewName = TEXT("Overview");
-					FString ModeNameString = ICVar->GetString();
-					FName ModeName = *ModeNameString;
-					if (ModeNameString.IsEmpty() || ModeName == OverviewName || ModeName == NAME_None)
-					{
-						NewBufferVisualizationMode = NAME_None;
-					}
-					else
-					{
-						if (GetBufferVisualizationData().GetMaterial(ModeName) == NULL)
-						{
-							// Mode is out of range, so display a message to the user, and reset the mode back to the previous valid one
-							UE_LOG(LogConsoleResponse, Warning, TEXT("Buffer visualization mode '%s' does not exist"), *ModeNameString);
-							NewBufferVisualizationMode = GetCurrentBufferVisualizationMode();
-							// todo: cvars are user settings, here the cvar state is used to avoid log spam and to auto correct for the user (likely not what the user wants)
-							ICVar->Set(*NewBufferVisualizationMode.GetPlainNameString(), ECVF_SetByCode);
-						}
-						else
-						{
-							NewBufferVisualizationMode = ModeName;
-						}
-					}
-				}
+                // Completing the of a ViewDamily configuration.
+                // The screen percentage is configurable in this function.
+                RenderFrameViewportManager->PostConfigureViewFamily(DCRenderTarget, DCViewFamily, ViewFamily, Views,
+                    ViewportRenderingFlags, GetDPIScale());
 
-				if (NewBufferVisualizationMode != GetCurrentBufferVisualizationMode())
-				{
-					SetCurrentBufferVisualizationMode(NewBufferVisualizationMode);
-				}
-			}
-
-			TMap<ULocalPlayer*, FSceneView*> PlayerViewMap;
-			FAudioDeviceHandle RetrievedAudioDevice = MyWorld->GetAudioDevice();
-			TArray<FSceneView*> Views;
-
-			for (FDisplayClusterRenderFrameTargetView& DCView : DCViewFamily.Views)
-			{
-				const FDisplayClusterViewport_Context ViewportContext = DCView.Viewport->GetContexts()[DCView.ContextNum];
-
-				/// !!!! disguise customizations
-				auto & Info = FRenderStreamModule::Get()->GetViewportInfo(DCView.Viewport->GetId());
-				if (Info.PlayerId != -1)
-				{
-					APlayerController * PolicyController = UGameplayStatics::GetPlayerControllerFromID(World, Info.PlayerId);
-					if (PolicyController)
-						LocalPlayer = PolicyController->GetLocalPlayer();
-				}
-				/// !!!! disguise customizations
-
-				// Calculate the player's view information.
-				FVector		ViewLocation;
-				FRotator	ViewRotation;
-				FSceneView* View = RenderFrameViewportManager->CalcSceneView(LocalPlayer, &ViewFamily, ViewLocation, ViewRotation, InViewport, nullptr, ViewportContext.StereoViewIndex);
-
-				if (View && (!DCView.IsViewportContextCanBeRendered() || ViewFamily.RenderTarget == nullptr))
-				{
-					ViewFamily.Views.Remove(View);
-
-					delete View;
-					View = nullptr;
-				}
-
-				if (View)
-				{
-					Views.Add(View);
-
-					/// !!!! disguise customizations
-					UpdateView(&ViewFamily, View, Info);
-					/// !!!! disguise customizations
-
-					// Apply viewport context settings to view (crossGPU, visibility, etc)
-					DCView.Viewport->SetupSceneView(DCView.ContextNum, World, ViewFamily, *View);
-
-					// We don't allow instanced stereo currently
-					View->bIsInstancedStereoEnabled = false;
-					View->bShouldBindInstancedViewUB = false;
-
-					if (View->Family->EngineShowFlags.Wireframe)
-					{
-						// Wireframe color is emissive-only, and mesh-modifying materials do not use material substitution, hence...
-						View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-						View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-					}
-					else if (View->Family->EngineShowFlags.OverrideDiffuseAndSpecular)
-					{
-						View->DiffuseOverrideParameter = FVector4f(GEngine->LightingOnlyBrightness.R, GEngine->LightingOnlyBrightness.G, GEngine->LightingOnlyBrightness.B, 0.0f);
-						View->SpecularOverrideParameter = FVector4f(.1f, .1f, .1f, 0.0f);
-					}
-					else if (View->Family->EngineShowFlags.LightingOnlyOverride)
-					{
-						View->DiffuseOverrideParameter = FVector4f(GEngine->LightingOnlyBrightness.R, GEngine->LightingOnlyBrightness.G, GEngine->LightingOnlyBrightness.B, 0.0f);
-						View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-					}
-					else if (View->Family->EngineShowFlags.ReflectionOverride)
-					{
-						View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-						View->SpecularOverrideParameter = FVector4f(1, 1, 1, 0.0f);
-						View->NormalOverrideParameter = FVector4f(0, 0, 1, 0.0f);
-						View->RoughnessOverrideParameter = FVector2D(0.0f, 0.0f);
-					}
-
-					if (!View->Family->EngineShowFlags.Diffuse)
-					{
-						View->DiffuseOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-					}
-
-					if (!View->Family->EngineShowFlags.Specular)
-					{
-						View->SpecularOverrideParameter = FVector4f(0.f, 0.f, 0.f, 0.f);
-					}
-
-					View->CurrentBufferVisualizationMode = GetCurrentBufferVisualizationMode();
-
-					View->CameraConstrainedViewRect = View->UnscaledViewRect;
-
-					// Enable per-view Lumen scene
-					if (DisplayClusterLumenPerView->GetInt())
-					{
-						View->State->AddLumenSceneData(MyWorld->Scene);
-					}
-					else
-					{
-						View->State->RemoveLumenSceneData(MyWorld->Scene);
-					}
-
-					{
-						// Save the location of the view.
-						LocalPlayer->LastViewLocation = ViewLocation;
-
-						PlayerViewMap.Add(LocalPlayer, View);
-
-						// Update the listener.
-						if (RetrievedAudioDevice && PlayerController != NULL)
-						{
-							bool bUpdateListenerPosition = true;
-
-							// If the main audio device is used for multiple PIE viewport clients, we only
-							// want to update the main audio device listener position if it is in focus
-							if (GEngine)
-							{
-								FAudioDeviceManager* AudioDeviceManager = GEngine->GetAudioDeviceManager();
-
-								// If there is more than one world referencing the main audio device
-								if (AudioDeviceManager->GetNumMainAudioDeviceWorlds() > 1)
-								{
-									uint32 MainAudioDeviceID = GEngine->GetMainAudioDeviceID();
-									if (AudioDevice->DeviceID == MainAudioDeviceID && !HasAudioFocus())
-									{
-										bUpdateListenerPosition = false;
-									}
-								}
-							}
-
-							if (bUpdateListenerPosition)
-							{
-								FVector Location;
-								FVector ProjFront;
-								FVector ProjRight;
-								PlayerController->GetAudioListenerPosition(Location, ProjFront, ProjRight);
-
-								FTransform ListenerTransform(FRotationMatrix::MakeFromXY(ProjFront, ProjRight));
-
-								// Allow the HMD to adjust based on the head position of the player, as opposed to the view location
-								if (GEngine->XRSystem.IsValid() && GEngine->StereoRenderingDevice.IsValid() && GEngine->StereoRenderingDevice->IsStereoEnabled())
-								{
-									const FVector Offset = GEngine->XRSystem->GetAudioListenerOffset();
-									Location += ListenerTransform.TransformPositionNoScale(Offset);
-								}
-
-								ListenerTransform.SetTranslation(Location);
-								ListenerTransform.NormalizeRotation();
-
-								uint32 ViewportIndex = PlayerViewMap.Num() - 1;
-								RetrievedAudioDevice->SetListener(MyWorld, ViewportIndex, ListenerTransform, (View->bCameraCut ? 0.f : MyWorld->GetDeltaSeconds()));
-
-								FVector OverrideAttenuation;
-								if (PlayerController->GetAudioListenerAttenuationOverridePosition(OverrideAttenuation))
-								{
-									RetrievedAudioDevice->SetListenerAttenuationOverride(ViewportIndex, OverrideAttenuation);
-								}
-								else
-								{
-									RetrievedAudioDevice->ClearListenerAttenuationOverride(ViewportIndex);
-								}
-							}
-						}
-					}
-
-					// Add view information for resource streaming. Allow up to 5X boost for small FOV.
-					const float StreamingScale = 1.f / FMath::Clamp<float>(View->LODDistanceFactor, .2f, 1.f);
-					IStreamingManager::Get().AddViewInformation(View->ViewMatrices.GetViewOrigin(), View->UnscaledViewRect.Width(), View->UnscaledViewRect.Width() * View->ViewMatrices.GetProjectionMatrix().M[0][0], StreamingScale);
-					MyWorld->ViewLocationsRenderedLastFrame.Add(View->ViewMatrices.GetViewOrigin());
-
-					FWorldCachedViewInfo& WorldViewInfo = World->CachedViewInfoRenderedLastFrame.AddDefaulted_GetRef();
-					WorldViewInfo.ViewMatrix = View->ViewMatrices.GetViewMatrix();
-					WorldViewInfo.ProjectionMatrix = View->ViewMatrices.GetProjectionMatrix();
-					WorldViewInfo.ViewProjectionMatrix = View->ViewMatrices.GetViewProjectionMatrix();
-					WorldViewInfo.ViewToWorld = View->ViewMatrices.GetInvViewMatrix();
-					World->LastRenderTime = World->GetTimeSeconds();
-				}
-			}
-
-#if CSV_PROFILER
-			UpdateCsvCameraStats(PlayerViewMap);
-#endif
-			if (ViewFamily.Views.Num() > 0)
-			{
-				FinalizeViews(&ViewFamily, PlayerViewMap);
-
-				// Force screen percentage show flag to be turned off if not supported.
-				if (!ViewFamily.SupportsScreenPercentage())
-				{
-					ViewFamily.EngineShowFlags.ScreenPercentage = false;
-				}
-
-				// Set up secondary resolution fraction for the view family.
-				if (ViewFamily.SupportsScreenPercentage())
-				{
-					float CustomSecondaryScreenPercentage = IConsoleManager::Get().FindConsoleVariable(TEXT("r.SecondaryScreenPercentage.GameViewport"), false)->GetFloat();
-					if (CustomSecondaryScreenPercentage > 0.0)
-					{
-						// Override secondary resolution fraction with CVar.
-						ViewFamily.SecondaryViewFraction = FMath::Min(CustomSecondaryScreenPercentage / 100.0f, 1.0f);
-					}
-					else
-					{
-						// Automatically compute secondary resolution fraction from DPI.
-						ViewFamily.SecondaryViewFraction = GetDPIDerivedResolutionFraction();
-					}
-
-					check(ViewFamily.SecondaryViewFraction > 0.0f);
-				}
-
-				checkf(ViewFamily.GetScreenPercentageInterface() == nullptr,
-					TEXT("Some code has tried to set up an alien screen percentage driver, that could be wrong if not supported very well by the RHI."));
-
-				// Setup main view family with screen percentage interface by dynamic resolution if screen percentage is enabled.
-	#if WITH_DYNAMIC_RESOLUTION
-				if (ViewFamily.EngineShowFlags.ScreenPercentage)
-				{
-					FDynamicResolutionStateInfos DynamicResolutionStateInfos;
-					GEngine->GetDynamicResolutionCurrentStateInfos(DynamicResolutionStateInfos);
-
-					// Do not allow dynamic resolution to touch the view family if not supported to ensure there is no possibility to ruin
-					// game play experience on platforms that does not support it, but have it enabled by mistake.
-					if (DynamicResolutionStateInfos.Status == EDynamicResolutionStatus::Enabled)
-					{
-						GEngine->EmitDynamicResolutionEvent(EDynamicResolutionStateEvent::BeginDynamicResolutionRendering);
-						GEngine->GetDynamicResolutionState()->SetupMainViewFamily(ViewFamily);
-					}
-					else if (DynamicResolutionStateInfos.Status == EDynamicResolutionStatus::DebugForceEnabled)
-					{
-						GEngine->EmitDynamicResolutionEvent(EDynamicResolutionStateEvent::BeginDynamicResolutionRendering);
-						ViewFamily.SetScreenPercentageInterface(new FLegacyScreenPercentageDriver(
-							ViewFamily,
-							DynamicResolutionStateInfos.ResolutionFractionApproximations[GDynamicPrimaryResolutionFraction],
-							DynamicResolutionStateInfos.ResolutionFractionUpperBounds[GDynamicPrimaryResolutionFraction]));
-					}
-
-	#if CSV_PROFILER
-					if (DynamicResolutionStateInfos.ResolutionFractionApproximations[GDynamicPrimaryResolutionFraction] >= 0.0f)
-					{
-						CSV_CUSTOM_STAT_GLOBAL(DynamicResolutionPercentage, DynamicResolutionStateInfos.ResolutionFractionApproximations[GDynamicPrimaryResolutionFraction] * 100.0f, ECsvCustomStatOp::Set);
-					}
-	#endif
-				}
-	#endif
-
-				// If a screen percentage interface was not set by dynamic resolution, then create one matching legacy behavior.
-				if (ViewFamily.GetScreenPercentageInterface() == nullptr)
-				{
-					// In case of stereo, we set the same buffer ratio for both left and right views (taken from left)
-					float CustomBufferRatio = DCViewFamily.CustomBufferRatio;
-
-					float GlobalResolutionFraction = 1.0f;
-					float SecondaryScreenPercentage = ViewFamily.SecondaryViewFraction;
-
-					if (ViewFamily.EngineShowFlags.ScreenPercentage)
-					{
-						// Get global view fraction set by r.ScreenPercentage.
-						GlobalResolutionFraction = CustomBufferRatio;
-
-						// We need to split the screen percentage if below 0.5 because TAA upscaling only works well up to 2x.
-						if (GlobalResolutionFraction < 0.5f)
-						{
-							SecondaryScreenPercentage = 2.0f * GlobalResolutionFraction;
-							GlobalResolutionFraction = 0.5f;
-						}
-					}
-
-					ViewFamily.SetScreenPercentageInterface(new FLegacyScreenPercentageDriver(
-						ViewFamily, GlobalResolutionFraction));
-
-					ViewFamily.SecondaryViewFraction = SecondaryScreenPercentage;
-				}
-				else if (bStereoRendering)
-				{
-					// Change screen percentage method to raw output when doing dynamic resolution with VR if not using TAA upsample.
-					for (FSceneView* View : Views)
-					{
-						if (View->PrimaryScreenPercentageMethod == EPrimaryScreenPercentageMethod::SpatialUpscale)
-						{
-							View->PrimaryScreenPercentageMethod = EPrimaryScreenPercentageMethod::RawOutput;
-						}
-					}
-				}
-
-				ViewFamily.bIsHDR = GetWindow().IsValid() ? GetWindow().Get()->GetIsHDR() : false;
+                ViewFamily.bIsHDR = GetWindow().IsValid() ? GetWindow().Get()->GetIsHDR() : false;
 
 #if WITH_MGPU
-				ViewFamily.bForceCopyCrossGPU = DisplayClusterForceCopyCrossGPU->GetInt() != 0;
+                ViewFamily.bForceCopyCrossGPU = GDisplayClusterForceCopyCrossGPU != 0;
 #endif
 
-				ViewFamily.ProfileDescription = DCViewFamily.Views[0].Viewport->GetId();
-				if (!ViewFamily.ProfileDescription.IsEmpty())
-				{
-					ViewFamily.ProfileSceneRenderTime = ((FDisplayClusterSceneViewport*)InViewport)->GetNextHistoryWriteAddress(ViewFamily.ProfileDescription);
-				}
+                ViewFamily.ProfileDescription = DCViewFamily.Views[0].Viewport->GetId();
 
-				// Draw the player views.
-				if (!bDisableWorldRendering && PlayerViewMap.Num() > 0 && FSlateApplication::Get().GetPlatformApplication()->IsAllowedToRender()) //-V560
-				{
-					// If we reach here, the view family should be rendered
-					bIsFamilyVisible = true;
-				}
-			}
+                // Draw the player views.
+                if (!bDisableWorldRendering && PlayerViewMap.Num() > 0 && FSlateApplication::Get().GetPlatformApplication()->IsAllowedToRender()) //-V560
+                {
+                    // If we reach here, the view family should be rendered
+                    bIsFamilyVisible = true;
+                }
+            }
 
-			if (!bIsFamilyVisible)
-			{
-				// Family didn't end up visible, remove last view family from the array
-				delete ViewFamilies.Pop();
-			}
-		}
-	}
+            if (!bIsFamilyVisible)
+            {
+                // Family didn't end up visible, remove last view family from the array
+                delete ViewFamilies.Pop();
+            }
+        }
+    }
 
-	// Trigger PreSubmitViewFamilies event before submitting to render
-	IDisplayCluster::Get().GetCallbacks().OnDisplayClusterPreSubmitViewFamilies().Broadcast(ViewFamilies);
+    // Trigger PreSubmitViewFamilies event before submitting to render
+    IDisplayCluster::Get().GetCallbacks().OnDisplayClusterPreSubmitViewFamilies().Broadcast(ViewFamilies);
 
-	// We gathered all the view families, now render them
-	if (!ViewFamilies.IsEmpty())
-	{
-		if (ViewFamilies.Num() > 1)
-		{
+    // We gathered all the view families, now render them
+    if (!ViewFamilies.IsEmpty())
+    {
+        if (ViewFamilies.Num() > 1)
+        {
 #if WITH_MGPU
-			if (DisplayClusterSortViews->GetInt())
-			{
-				ViewFamilies.StableSort(FCompareViewFamilyBySizeAndGPU());
-			}
+            if (GDisplayClusterSortViews)
+            {
+                ViewFamilies.StableSort(FCompareViewFamilyBySizeAndGPU());
+            }
 #endif  // WITH_MGPU
 
-			// Initialize some flags for which view family is which, now that any view family reordering has been handled.
-			ViewFamilies[0]->bAdditionalViewFamily = false;
-			ViewFamilies[0]->bIsFirstViewInMultipleViewFamily = true;
-			ViewFamilies[0]->bIsMultipleViewFamily = true;
+            // Initialize some flags for which view family is which, now that any view family reordering has been handled.
+            ViewFamilies[0]->bAdditionalViewFamily = false;
+            ViewFamilies[0]->bIsFirstViewInMultipleViewFamily = true;
 
-			for (int32 FamilyIndex = 1; FamilyIndex < ViewFamilies.Num(); FamilyIndex++)
-			{
-				FSceneViewFamily& ViewFamily = *ViewFamilies[FamilyIndex];
-				ViewFamily.bAdditionalViewFamily = true;
-				ViewFamily.bIsFirstViewInMultipleViewFamily = false;
-				ViewFamily.bIsMultipleViewFamily = true;
-			}
-		}
+            for (int32 FamilyIndex = 1; FamilyIndex < ViewFamilies.Num(); FamilyIndex++)
+            {
+                FSceneViewFamily& ViewFamily = *ViewFamilies[FamilyIndex];
+                ViewFamily.bAdditionalViewFamily = true;
+                ViewFamily.bIsFirstViewInMultipleViewFamily = false;
+            }
+        }
 
-		if (DisplayClusterSingleRender->GetInt())
-		{
-			GetRendererModule().BeginRenderingViewFamilies(
-				SceneCanvas, TArrayView<FSceneViewFamily*>((FSceneViewFamily**)(ViewFamilies.GetData()), ViewFamilies.Num()));
-		}
-		else
-		{
-			for (FSceneViewFamilyContext* ViewFamilyContext : ViewFamilies)
-			{
-				FSceneViewFamily& ViewFamily = *ViewFamilyContext;
+        if (GDisplayClusterSingleRender)
+        {
+            GetRendererModule().BeginRenderingViewFamilies(
+                SceneCanvas, MakeArrayView(reinterpret_cast<FSceneViewFamily* const*>(ViewFamilies.GetData()), ViewFamilies.Num()));
+        }
+        else
+        {
+            for (FSceneViewFamilyContext* ViewFamilyContext : ViewFamilies)
+            {
+                FSceneViewFamily& ViewFamily = *ViewFamilyContext;
 
-				GetRendererModule().BeginRenderingViewFamily(SceneCanvas, &ViewFamily);
+                GetRendererModule().BeginRenderingViewFamily(SceneCanvas, &ViewFamily);
 
-				if (GNumExplicitGPUsForRendering > 1)
-				{
-					const FRHIGPUMask SubmitGPUMask = ViewFamily.Views.Num() == 1 ? ViewFamily.Views[0]->GPUMask : FRHIGPUMask::All();
-					ENQUEUE_RENDER_COMMAND(UDisplayClusterViewportClient_SubmitCommandList)(
-						[SubmitGPUMask](FRHICommandListImmediate& RHICmdList)
-					{
-						SCOPED_GPU_MASK(RHICmdList, SubmitGPUMask);
-						RHICmdList.SubmitCommandsHint();
-					});
-				}
-			}
-		}
-	}
-	else
-	{
-		// Or if none to render, do logic for when rendering is skipped
-		GetRendererModule().PerFrameCleanupIfSkipRenderer();
-	}
+                if (GNumExplicitGPUsForRendering > 1)
+                {
+                    const FRHIGPUMask SubmitGPUMask = ViewFamily.Views.Num() == 1 ? ViewFamily.Views[0]->GPUMask : FRHIGPUMask::All();
+                    ENQUEUE_RENDER_COMMAND(UDisplayClusterViewportClient_SubmitCommandList)(
+                        [SubmitGPUMask](FRHICommandListImmediate& RHICmdList)
+                        {
+                            SCOPED_GPU_MASK(RHICmdList, SubmitGPUMask);
+                            RHICmdList.SubmitCommandsHint();
+                        });
+                }
+            }
+        }
+    }
+    else
+    {
+        // Or if none to render, do logic for when rendering is skipped
+        GetRendererModule().PerFrameCleanupIfSkipRenderer();
+    }
 
-	// Handle special viewports game-thread logic at frame end
-	// custom postprocess single frame flag must be removed at frame end on game thread
-	DCRenderDevice->FinalizeNewFrame();
+    // Handle special viewports game-thread logic at frame end
+    // custom postprocess single frame flag must be removed at frame end on game thread
+    DCRenderDevice->FinalizeNewFrame();
 
-	// Beyond this point, only UI rendering independent from dynamic resolution.
-	GEngine->EmitDynamicResolutionEvent(EDynamicResolutionStateEvent::EndDynamicResolutionRendering);
+    // Update level streaming.
+    MyWorld->UpdateLevelStreaming();
 
-	// Update level streaming.
-	MyWorld->UpdateLevelStreaming();
+    // Remove temporary debug lines.
+    constexpr const UWorld::ELineBatcherType LineBatchersToFlush[] = { UWorld::ELineBatcherType::World, UWorld::ELineBatcherType::Foreground };
+    World->FlushLineBatchers(LineBatchersToFlush);
 
-	// Remove temporary debug lines.
-	if (MyWorld->LineBatcher != nullptr)
-	{
-		MyWorld->LineBatcher->Flush();
-	}
+    // Draw FX debug information.
+    if (MyWorld->FXSystem)
+    {
+        MyWorld->FXSystem->DrawDebug(SceneCanvas);
+    }
 
-	if (MyWorld->ForegroundLineBatcher != nullptr)
-	{
-		MyWorld->ForegroundLineBatcher->Flush();
-	}
+    {
+        //ensure canvas has been flushed before rendering UI
+        SceneCanvas->Flush_GameThread();
 
-	// Draw FX debug information.
-	if (MyWorld->FXSystem)
-	{
-		MyWorld->FXSystem->DrawDebug(SceneCanvas);
-	}
+        // After all render target rendered call nDisplay frame rendering
+        RenderFrameViewportManager->RenderFrame(InViewport);
 
-	{
-		//ensure canvas has been flushed before rendering UI
-		SceneCanvas->Flush_GameThread();
+        OnDrawn().Broadcast();
 
-		// After all render target rendered call nDisplay frame rendering
-		RenderFrameViewportManager->RenderFrame(InViewport);
+        // Allow the viewport to render additional stuff
+        PostRender(DebugCanvasObject);
+    }
 
-		OnDrawn().Broadcast();
+    // Grab the player camera location and orientation so we can pass that along to the stats drawing code.
+    FVector PlayerCameraLocation = FVector::ZeroVector;
+    FRotator PlayerCameraRotation = FRotator::ZeroRotator;
+    PlayerController->GetPlayerViewPoint(PlayerCameraLocation, PlayerCameraRotation);
 
-		// Allow the viewport to render additional stuff
-		PostRender(DebugCanvasObject);
-	}
+    if (DebugCanvas)
+    {
+        // Reset the debug canvas to be full-screen before drawing the console
+        // (the debug draw service above has messed with the viewport size to fit it to a single player's subregion)
+        DebugCanvasObject->Init(DebugCanvasSize.X, DebugCanvasSize.Y, NULL, DebugCanvas);
 
-	// Grab the player camera location and orientation so we can pass that along to the stats drawing code.
-	FVector PlayerCameraLocation = FVector::ZeroVector;
-	FRotator PlayerCameraRotation = FRotator::ZeroRotator;
-	PlayerController->GetPlayerViewPoint(PlayerCameraLocation, PlayerCameraRotation);
+        DrawStatsHUD(MyWorld, InViewport, DebugCanvas, DebugCanvasObject, DebugProperties, PlayerCameraLocation, PlayerCameraRotation);
 
-	if (DebugCanvas)
-	{
-		// Reset the debug canvas to be full-screen before drawing the console
-		// (the debug draw service above has messed with the viewport size to fit it to a single player's subregion)
-		DebugCanvasObject->Init(DebugCanvasSize.X, DebugCanvasSize.Y, NULL, DebugCanvas);
-
-		DrawStatsHUD(MyWorld, InViewport, DebugCanvas, DebugCanvasObject, DebugProperties, PlayerCameraLocation, PlayerCameraRotation);
-
-		if (GEngine->IsStereoscopic3D(InViewport))
-		{
+        if (GEngine->IsStereoscopic3D(InViewport))
+        {
 #if 0 //!UE_BUILD_SHIPPING
-			// TODO: replace implementation in OculusHMD with a debug renderer
-			if (GEngine->XRSystem.IsValid())
-			{
-				GEngine->XRSystem->DrawDebug(DebugCanvasObject);
-			}
+            // TODO: replace implementation in OculusHMD with a debug renderer
+            if (GEngine->XRSystem.IsValid())
+            {
+                GEngine->XRSystem->DrawDebug(DebugCanvasObject);
+            }
 #endif
-		}
+        }
 
-		if (DisplayClusterDebugDraw->GetInt() && !ViewFamilies.IsEmpty())
-		{
-			UDebugDrawService::Draw(ViewFamilies.Last()->EngineShowFlags, InViewport, const_cast<FSceneView*>(ViewFamilies.Last()->Views[0]), DebugCanvas, DebugCanvasObject);
-		}
+        if (GDisplayClusterDebugDraw && !ViewFamilies.IsEmpty())
+        {
+            UDebugDrawService::Draw(ViewFamilies.Last()->EngineShowFlags, InViewport, const_cast<FSceneView*>(ViewFamilies.Last()->Views[0]), DebugCanvas, DebugCanvasObject);
+        }
 
-		// Render the console absolutely last because developer input is was matter the most.
-		if (ViewportConsole)
-		{
-			ViewportConsole->PostRender_Console(DebugCanvasObject);
-		}
-	}
+        // Render the console absolutely last because developer input is was matter the most.
+        if (ViewportConsole)
+        {
+            ViewportConsole->PostRender_Console(DebugCanvasObject);
+        }
+    }
 
-	if (!ViewFamilies.IsEmpty())
-	{
-		for (FSceneViewFamilyContext* ViewFamilyContext : ViewFamilies)
-		{
-			delete ViewFamilyContext;
-		}
-		ViewFamilies.Empty();
-	}
+    if (!ViewFamilies.IsEmpty())
+    {
+        for (FSceneViewFamilyContext* ViewFamilyContext : ViewFamilies)
+        {
+            delete ViewFamilyContext;
+        }
+        ViewFamilies.Empty();
+    }
 
-	OnEndDraw().Broadcast();
+    OnEndDraw().Broadcast();
 }
-
 /// DisplayClusterViewportClient.cpp copy-pasta
 
 void URenderStreamViewportClient::UpdateView(FSceneViewFamily* ViewFamily, FSceneView* View, const FRenderStreamViewportInfo& Info)

--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -27,18 +27,25 @@ FString FRenderStreamSyncFrameData::SerializeToString() const
 
 bool FRenderStreamSyncFrameData::DeserializeFromString(const FString& Str)
 {
-    TArray<uint8> TempBytes;
-    TempBytes.AddUninitialized(Str.Len());
-    StringToBytes(Str, TempBytes.GetData(), Str.Len());
+    EDisplayClusterNodeRole NodeRole = IDisplayCluster::Get().GetClusterMgr()->GetClusterRole();
 
-    FMemoryReader Ar(TempBytes);
-    if (Map(Ar))
+    if (NodeRole == EDisplayClusterNodeRole::Secondary)
     {
-        FollowerReceive();
-        return true;
+        TArray<uint8> TempBytes;
+        TempBytes.AddUninitialized(Str.Len());
+        StringToBytes(Str, TempBytes.GetData(), Str.Len());
+
+        FMemoryReader Ar(TempBytes);
+        if (Map(Ar))
+        {
+            FollowerReceive();
+            return true;
+        }
+
+        return false;
     }
 
-    return false;
+    return true;
 }
 
 bool FRenderStreamSyncFrameData::Map(FArchive& Ar)

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v0"
+#define RS_PLUGIN_VERSION "RS2.0-UE6-v0"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE6-v0"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.6-v0"
 
 class RenderStreamLink
 {

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -540,15 +540,22 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     Cache->ExposedParams.Empty();
     GenerateParameters(Cache->ExposedParams, Level->GetLevelScriptActor());
 
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+
     // We can only know the sublevels of the persistent level.
     if (Level->IsPersistentLevel())
     {
         Cache->SubLevels.Empty();
-        for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
+        
+        // Sublevels are not loaded when SceneSelector is None so they shouldn't be added to the cache
+        if (settings->SceneSelector != ERenderStreamSceneSelector::None)
         {
-            if (auto WorldAsset = SubLevel->GetWorldAsset())
+            for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
             {
-                Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                if (auto WorldAsset = SubLevel->GetWorldAsset())
+                {
+                    Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                }
             }
         }
     }

--- a/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
@@ -241,7 +241,7 @@ void DisableShowFlag(const FRenderStreamChannelInfo& Info, const FString& LevelN
         }
     }
 
-    RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(TEXT("Could not fix %s. Channel definition %s not found in level %."), *SettingName, *Info.Name, *LevelName))));
+    RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(TEXT("Could not fix %s. Channel definition %s not found in level %s."), *SettingName, *Info.Name, *LevelName))));
 
 }
 

--- a/uplugin_template.json
+++ b/uplugin_template.json
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EngineVersion": "5.5.0",
+	"EngineVersion": "5.6.0",
 	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,


### PR DESCRIPTION
[RSP-370](https://d3technologies.atlassian.net/browse/RSP-370)

Technical Description:

There were some small issues getting it to build which required removing/modifying certain parts. The main issue was that when awaiting frame data RenderStream could constantly timeout. This happened because for some reason now nDisplay calls the DeserializeFromString function which the RenderStream plugin only assumes will be called on follower nodes. This causes d3 to treat the controller node as a follower which results in no frames being sent. The fix for this was to only execute the follower logic in DeserializeFromString if the node is actually a follower.

[RSP-370]: https://d3technologies.atlassian.net/browse/RSP-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ