### PR TITLE
UE DX11 Assets Do Not Work With Unreal 5.5 and Texture Parameters

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -688,6 +688,10 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     RenderStreamLink::SenderFrame data = {};
                     if (toggle == "D3D11")
                     {
+                        {
+                            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
+                            RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
+                        }
                         data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX11_TEXTURE;
                         data.dx11.resource = static_cast<ID3D11Resource*>(resource);
                         auto err = RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data);


### PR DESCRIPTION
(RSP-373)[https://d3technologies.atlassian.net/browse/RSP-373]

When running RenderStream using UE 5.5 and the dx11 backend the workload immediately crashes. This is because dx11 complains that the context is being accessed from 2 different threads at the same time. The fix is to call an immediate flush before grabbing the texture parameter. This executes all the queued render commands before executing ours.