### PR TITLE
UE crashes when starting a workload with custom events and a sub level and scene selection set to None

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -546,15 +546,22 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     Cache->ExposedParams.Empty();
     GenerateParameters(Cache->ExposedParams, Level->GetLevelScriptActor());
 
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+
     // We can only know the sublevels of the persistent level.
     if (Level->IsPersistentLevel())
     {
         Cache->SubLevels.Empty();
-        for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
+        
+        // Sublevels are not loaded when SceneSelector is None so they shouldn't be added to the cache
+        if (settings->SceneSelector != ERenderStreamSceneSelector::None)
         {
-            if (auto WorldAsset = SubLevel->GetWorldAsset())
+            for (ULevelStreaming* SubLevel : Level->GetWorld()->GetStreamingLevels())
             {
-                Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                if (auto WorldAsset = SubLevel->GetWorldAsset())
+                {
+                    Cache->SubLevels.Add(WorldAsset->GetPackage()->GetPathName());
+                }
             }
         }
     }


### PR DESCRIPTION
[RSP-361](https://d3technologies.atlassian.net/browse/RSP-361?atlOrigin=eyJpIjoiZGIzYTA3Mjg4NWVhNDU5ZDhkYTRjMTMwZTVlZGEzN2MiLCJwIjoiaiJ9)

**Technical Description:**

When the scene selection is set to None then the sublevels are not loaded. However in the plugin, the sublevels of a persistent level are added to the cache regardless of what the mode is set to. This causes any customs events present in the sublevel to be saved to the schema which then causes UE to crash on startup because it is trying to find a custom event for a level that was never loaded. The fix for this is just to check the scene selection mode when updating the level cache.

[RSP-361]: https://d3technologies.atlassian.net/browse/RSP-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ