### PR TITLE
RSP-366 added more trace info to controller receive

### DIFF
--- a/CHANGELOG_UE5.3.md
+++ b/CHANGELOG_UE5.3.md
@@ -1,3 +1,7 @@
+# RS2.0-UE5.3-v6
+Compatible with disguise designer version r25.0 and above.
+* Added more profiling granularity to certain functions
+
 # RS2.0-UE5.3-v2
 Compatible with disguise designer version r25.0 and above.
 * Fix for skeleton joint offsets not being applied in correct direction

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -308,6 +308,7 @@ void FRenderStreamModule::LoadSchemas(const UWorld& World)
 
 void FRenderStreamModule::ApplyScene(uint32_t sceneId)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamModule::ApplyScene()"));
     check(m_sceneSelector != nullptr);
     m_sceneSelector->ApplyScene(*GWorld, sceneId);
 }
@@ -359,6 +360,8 @@ bool UpdateViewport(FFrameStreamPtr Stream)
 
 void FRenderStreamModule::ConfigureStream(FFrameStreamPtr Stream)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamModule::ConfigureStream()"));
+
     FString const& Name = Stream->Name();
     if (!Stream)
     {
@@ -454,6 +457,8 @@ void FRenderStreamModule::ConfigureStream(FFrameStreamPtr Stream)
 
 bool FRenderStreamModule::PopulateStreamPool()
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamModule::PopulateStreamPool()"));
+
     if (!StreamPool) {
         UE_LOG(LogRenderStream, Log, TEXT("Abort populating stream pool, not initialized."));
         return false;
@@ -565,6 +570,8 @@ bool FRenderStreamModule::PopulateStreamPool()
 
 void FRenderStreamModule::ApplyCameras(const RenderStreamLink::FrameData& frameData)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamModule::ApplyCameras()"));
+
     for (auto& pair  : ViewportInfos)
     {
         const FFrameStreamPtr stream = StreamPool->GetStream(pair.Key);
@@ -579,6 +586,8 @@ void FRenderStreamModule::ApplyCameras(const RenderStreamLink::FrameData& frameD
 
 void FRenderStreamModule::ApplyCameraData(FRenderStreamViewportInfo& info, const RenderStreamLink::FrameData& frameData, const RenderStreamLink::CameraData& cameraData)
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamModule::ApplyCameraData()"));
+
     // Each call must always have a frame response, because there will be a corresponding render call.
     {
         std::lock_guard<std::mutex> guard(info.m_frameResponsesLock);

--- a/Source/RenderStream/Private/SceneSelector_Maps.cpp
+++ b/Source/RenderStream/Private/SceneSelector_Maps.cpp
@@ -10,6 +10,8 @@ void SceneSelector_Maps::ApplyScene(const UWorld& world, uint32_t sceneId)
         return;
     }
 
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("SceneSelector_Maps::ApplyScene()"));
+
     MapData& map = m_maps[sceneId];
 
     if (world.GetName() != map.Name)

--- a/Source/RenderStream/Private/SceneSelector_None.cpp
+++ b/Source/RenderStream/Private/SceneSelector_None.cpp
@@ -38,6 +38,7 @@ void SceneSelector_None::ApplyScene(const UWorld& World, uint32_t SceneId)
         return;
     }
 
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("SceneSelector_None::ApplyScene()"));
     TArray<AActor*> LevelActors;
     GetAllLevels(LevelActors, World.PersistentLevel);
     ApplyParameters(SceneId, LevelActors);

--- a/Source/RenderStream/Private/SceneSelector_StreamingLevels.cpp
+++ b/Source/RenderStream/Private/SceneSelector_StreamingLevels.cpp
@@ -61,6 +61,8 @@ void SceneSelector_StreamingLevels::ApplyScene(const UWorld& World, uint32_t sce
         return;
     }
 
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("SceneSelector_StreamingLevels::ApplyScene()"));
+
     SchemaSpec& spec = m_specs[sceneId];
     if (spec.streamingLevel && !spec.streamingLevel->IsLevelLoaded())
     {

--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -81,6 +81,8 @@ bool FRenderStreamSyncFrameData::Map(FArchive& Ar)
 
 void FRenderStreamSyncFrameData::ControllerReceive()
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive()"));
+
     if (m_isQuitting)
     {
         // Process deferred quit status from last frame (deferred due to ndisplay sync)
@@ -88,7 +90,6 @@ void FRenderStreamSyncFrameData::ControllerReceive()
         return;
     }
 
-    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive()"));
     SCOPE_CYCLE_COUNTER(STAT_AwaitFrame);
     const double StartTime = FPlatformTime::Seconds();
     const RenderStreamLink::RS_ERROR Ret = RenderStreamLink::instance().rs_awaitFrameData(500, &m_frameData);
@@ -115,6 +116,7 @@ void FRenderStreamSyncFrameData::ControllerReceive()
     {
         if (Ret == RenderStreamLink::RS_ERROR_TIMEOUT)
         {
+            TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive() - timeout, setting new status message"));
             RenderStreamLink::instance().rs_setNewStatusMessage("Not requested");
         }
         else
@@ -127,6 +129,7 @@ void FRenderStreamSyncFrameData::ControllerReceive()
     {
         if (!m_frameDataValid)
         {
+            TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive() - invalid frame data, setting new status message"));
             RenderStreamLink::instance().rs_setNewStatusMessage("");
         }
 
@@ -227,6 +230,7 @@ void FRenderStreamSyncFrameData::Apply() const
 
 void FRenderStreamSyncFrameData::QuitNow() const
 {
+    TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::QuitNow()"));
     RenderStreamLink::instance().rs_setNewStatusMessage("");
     UE_LOG(LogRenderStream, Log, TEXT("Quitting due to RenderStream request"));
     FPlatformMisc::RequestExit(false);

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v2"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v6"
 
 class RenderStreamLink
 {


### PR DESCRIPTION
RSP-366

### Issue
ControllerReceive sometimes take a long time in some project, but profiling the project doesn't provide information about what is taking a long time in that function.

As seen in this image, we can see that ControllerReceive is called for 75ms, but we have no immediate information about what it did.
![image](https://github.com/user-attachments/assets/34ca64d2-d3ee-4714-b85e-12b568368604)

### Solution
Added TRACE_CPUPROFILER_EVENT_SCOPE in function used by the ControllerReceive function. This should give us a bit more granularity in the profile.

### QA
We probably won't be able to test every case added but in general:
* start a workload
* use Unreal Insights to profile the session
* inspect the profile to validate that we have more information about what has been done in the ControllerReceive

i.e.
We can see in this image that during the ControllerReceive call, we called Apply, ApplyScene, ApplyCamera, etc...
<img width="639" alt="image" src="https://github.com/user-attachments/assets/3532a1cf-4426-4446-a58b-d6a6856f7eaf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced CPU profiling capabilities to several key functions, enabling more detailed performance analysis within scene management and synchronization processes. Profiling markers now track execution durations in core scene application and data synchronization methods.
  - Updated plugin version to RS2.0-UE5.3-v6, ensuring compatibility with disguise designer version r25.0 and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->