### PR TITLE
RSP-377 compatibility issue with the SonyCameraAndDisplay plugin

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -532,7 +532,7 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
                 FString ChannelName = TCHAR_TO_UTF8(*(Definition->GetChannelName()));
                 Cache->Channels.Emplace(ChannelName);
                 FRenderStreamChannelInfo channelInfo = FRenderStreamValidation::GetChannelInfo(Definition, Level);
-                sanitizeChannelInfo(channelInfo);
+                SanitizeChannelInfo(channelInfo);
                 Cache->ChannelInfoMap.Emplace(ChannelName, channelInfo);
             }
         }

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -504,6 +504,15 @@ bool CheckOutLevelChannelCaches(TArray<ULevel*> Levels)
     return checkoutNotCancelled && allPackagesWriteable;
 }
 
+// Removes transient objects from the channel info in preparation to save the channel info into the cache
+void sanitizeChannelInfo(FRenderStreamChannelInfo& ChannelInfo)
+{
+    ChannelInfo.PostProcessSettings.WeightedBlendables.Array.RemoveAll([](const FWeightedBlendable& Blendable)
+    {
+        return Blendable.Object && Blendable.Object->IsA<UMaterialInstanceDynamic>();
+    });
+}
+
 URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
 {
     URenderStreamChannelCacheAsset* Cache = GetOrCreateCache(Level);
@@ -522,7 +531,9 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
             {
                 FString ChannelName = TCHAR_TO_UTF8(*(Definition->GetChannelName()));
                 Cache->Channels.Emplace(ChannelName);
-                Cache->ChannelInfoMap.Emplace(ChannelName, FRenderStreamValidation::GetChannelInfo(Definition, Level));
+                FRenderStreamChannelInfo channelInfo = FRenderStreamValidation::GetChannelInfo(Definition, Level);
+                sanitizeChannelInfo(channelInfo);
+                Cache->ChannelInfoMap.Emplace(ChannelName, channelInfo);
             }
         }
     }

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -505,7 +505,7 @@ bool CheckOutLevelChannelCaches(TArray<ULevel*> Levels)
 }
 
 // Removes transient objects from the channel info in preparation to save the channel info into the cache
-void sanitizeChannelInfo(FRenderStreamChannelInfo& ChannelInfo)
+void SanitizeChannelInfo(FRenderStreamChannelInfo& ChannelInfo)
 {
     ChannelInfo.PostProcessSettings.WeightedBlendables.Array.RemoveAll([](const FWeightedBlendable& Blendable)
     {


### PR DESCRIPTION
## Technical description

Every time a UE project is saved, the RenderStream plugin finds all cameras with a RenderStreamChannelDefinition attached to them and caches information about the camera actor. The crash is UnrealEditor raising an exception due to the RenderStream plugin attempting to save invalid objects:
- RS plugin tries to cache post-processing settings
- SonyCameraAndDisplay plugin adds temporary objects to post-processing settings
- UE throws exception

## Resolution

Exclude temporary objects specifically from the list of "WeightedBlendables" in the post-processing settings when caching them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents transient post-process materials from being retained in channel settings, reducing crashes and visual glitches during editing and playback.
  * Ensures channel cache stores cleaned channel data, improving stability and consistency of post-process blending across levels, sessions, and after reopening projects.
  * Reduces risk of corrupted or stale channel data appearing in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->