### PR TITLE
HDR Colour Transform for Texture Parameters

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -20,7 +20,13 @@
 #include <OpenColorIOColorTransform.h>
 #include <OpenColorIORendering.h>
 
-RenderStreamSceneSelector::~RenderStreamSceneSelector() = default;
+RenderStreamSceneSelector::~RenderStreamSceneSelector()
+{
+    if (m_textureColourTransform && m_textureColourTransform->IsRooted())
+    {
+        m_textureColourTransform->RemoveFromRoot();
+    }
+}
 
 void RenderStreamSceneSelector::GetAllLevels(TArray<AActor*>& Actors, ULevel * Level) const
 {
@@ -201,6 +207,27 @@ bool RenderStreamSceneSelector::ValidateParameters(const RenderStreamLink::Remot
             Actors.Num(), offset, sceneParameters.nParameters);
         return false;
     }
+
+    const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
+    if (settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource)
+    {
+        isColourConfigurationEnabled = true;
+
+        m_colourConversionSettings.ConfigurationSource = settings->OCIOConfig.ColorConfiguration.ConfigurationSource;
+
+        if (settings->OCIOConfig.ColorConfiguration.DestinationColorSpace.ColorSpaceIndex != INDEX_NONE)
+        {
+            m_colourConversionSettings.SourceColorSpace = settings->OCIOConfig.ColorConfiguration.DestinationColorSpace;
+            m_colourConversionSettings.DestinationColorSpace = settings->OCIOConfig.ColorConfiguration.SourceColorSpace;
+        }
+        else
+        {
+            m_colourConversionSettings.SourceColorSpace = settings->OCIOConfig.ColorConfiguration.SourceColorSpace;
+            m_colourConversionSettings.DestinationDisplayView = settings->OCIOConfig.ColorConfiguration.DestinationDisplayView;
+            m_colourConversionSettings.DisplayViewDirection = EOpenColorIOViewTransformDirection::Inverse;
+        }
+    }
+
 
     return true;
 }
@@ -520,6 +547,74 @@ void RenderStreamSceneSelector::ApplyParameters(uint32_t sceneId, const TArray<A
     m_floatValuesLast = floatValues; // event parameters need to lookup previous values
 }
 
+void RenderStreamSceneSelector::GetTextureParameter(const FString& toggle, const RenderStreamLink::ImageFrameData& frameData, size_t iImage, UTextureRenderTarget2D* Texture)
+{
+    ENQUEUE_RENDER_COMMAND(GetTex)(
+        [Texture, toggle, frameData, iImage](FRHICommandListImmediate& RHICmdList)
+        {
+            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Block %d"), iImage);
+            const auto rtResource = Texture->GetRenderTargetResource();
+            if (!rtResource)
+            {
+                return;
+            }
+            void* resource = rtResource->TextureRHI->GetNativeResource();
+
+            RenderStreamLink::SenderFrame data = {};
+            if (toggle == "D3D11")
+            {
+                data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX11_TEXTURE;
+                data.dx11.resource = static_cast<ID3D11Resource*>(resource);
+                auto err = RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data);
+            }
+            else if (toggle == "D3D12")
+            {
+                {
+                    SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
+                    RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
+                }
+
+                data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX12_TEXTURE;
+                data.dx12.resource = static_cast<ID3D12Resource*>(resource);
+
+                SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS getFrameImage2 %d"), iImage);
+                if (RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data) != RenderStreamLink::RS_ERROR_SUCCESS)
+                {
+
+                }
+            }
+            else if (toggle == "Vulkan")
+            {
+                {
+                    SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
+                    RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
+                }
+
+                FVulkanTexture* VulkanTexture = ResourceCast(rtResource->TextureRHI->GetTexture2D());
+                auto point2 = VulkanTexture->GetSizeXY();
+
+                data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_VULKAN_TEXTURE;
+                data.vk.memory = VulkanTexture->GetAllocationHandle();
+                data.vk.size = VulkanTexture->GetAllocationOffset() + VulkanTexture->GetMemorySize();
+                data.vk.format = frameData.format;
+                data.vk.width = uint32_t(point2.X);
+                data.vk.height = uint32_t(point2.Y);
+                // TODO: semaphores
+
+                SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS getFrameImage2 %d"), iImage);
+                if (RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data) != RenderStreamLink::RS_ERROR_SUCCESS)
+                {
+
+                }
+            }
+            else
+            {
+                UE_LOG(LogRenderStream, Error, TEXT("RenderStream tried to send frame with unsupported RHI backend."));
+                return;
+            }
+        });
+}
+
 void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const std::vector<float>& floatValues, size_t& iFloat, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals, size_t& textValues)
 {
     auto toggle = FHardwareInfo::GetHardwareInfo(NAME_RHI);
@@ -667,6 +762,12 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
             UObject* o = ObjectProperty->GetObjectPropertyValue(ObjectAddress);
             if (UTextureRenderTarget2D* Texture = Cast<UTextureRenderTarget2D>(o))
             {
+                if (iImage >= nImageVals)
+                {
+                    UE_LOG(LogRenderStream, Verbose, TEXT("Attempt to read a image value from disguise that is out of range. Does the metadata need to be regenerated?"));
+                    continue;
+                }
+
                 // Treat all incoming textures are in linear colour space to
                 // ensure consistent behaviour.
                 // Without this, UE applies gamma 2.2 to textures with
@@ -674,164 +775,100 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                 // as linear (RST-353).
                 Texture->SRGB = 0;
                 Texture->bForceLinearGamma = true;
-                if (iImage >= nImageVals)
-                {
-                    UE_LOG(LogRenderStream, Verbose, TEXT("Attempt to read a image value from disguise that is out of range. Does the metadata need to be regenerated?"));
-                    continue;
-                }
 
                 const RenderStreamLink::ImageFrameData& frameData = imageValues[iImage];
-                if (!Texture->bGPUSharedFlag || Texture->GetFormat() != formatMap[frameData.format].ue)
+
+                if (isColourConfigurationEnabled)
                 {
-                    Texture->bGPUSharedFlag = true;
-                    Texture->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
-                }
-                else
-                {
-                    Texture->ResizeTarget(frameData.width, frameData.height);
-                }
-
-                ENQUEUE_RENDER_COMMAND(GetTex)(
-                [this, toggle, Texture, frameData, iImage](FRHICommandListImmediate& RHICmdList)
-                {
-                    SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Block %d"), iImage);
-                    const auto rtResource = Texture->GetRenderTargetResource();
-                    if (!rtResource)
+                    if (!m_textureColourTransform)
                     {
-                        return;
+                        m_textureColourTransform = UKismetRenderingLibrary::CreateRenderTarget2D(
+                            Root,
+                            Texture->SizeX,
+                            Texture->SizeY,
+                            Texture->RenderTargetFormat
+                        );
+
+                        m_textureColourTransform->SRGB = 0;
+                        m_textureColourTransform->bForceLinearGamma = true;
+
+                        m_textureColourTransform->AddToRoot();
+                        m_textureColourTransform->UpdateResourceImmediate(true);
                     }
-                    void* resource = rtResource->TextureRHI->GetNativeResource();
 
-                    RenderStreamLink::SenderFrame data = {};
-                    if (toggle == "D3D11")
+                    if (Texture->OverrideFormat != EPixelFormat::PF_FloatRGBA)
                     {
-                        data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX11_TEXTURE;
-                        data.dx11.resource = static_cast<ID3D11Resource*>(resource);
-                        auto err = RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data);
-                    }
-                    else if (toggle == "D3D12")
-                    {
-                        {
-                            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
-                            RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
-                        }
-
-                        data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_DX12_TEXTURE;
-                        data.dx12.resource = static_cast<ID3D12Resource*>(resource);
-                        
-                        SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS getFrameImage2 %d"), iImage);
-                        if (RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data) != RenderStreamLink::RS_ERROR_SUCCESS)
-                        {
-
-                        }
-                    }
-                    else if (toggle == "Vulkan")
-                    {
-                        {
-                            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Flush"));
-                            RHICmdList.ImmediateFlush(EImmediateFlushType::FlushRHIThreadFlushResources);
-                        }
-
-                        FVulkanTexture* VulkanTexture = ResourceCast(rtResource->TextureRHI->GetTexture2D());
-                        auto point2 = VulkanTexture->GetSizeXY();
-
-                        data.type = RenderStreamLink::SenderFrameType::RS_FRAMETYPE_VULKAN_TEXTURE;
-                        data.vk.memory = VulkanTexture->GetAllocationHandle();
-                        data.vk.size = VulkanTexture->GetAllocationOffset() + VulkanTexture->GetMemorySize();
-                        data.vk.format = frameData.format;
-                        data.vk.width = uint32_t(point2.X);
-                        data.vk.height = uint32_t(point2.Y);
-                        // TODO: semaphores
-
-                        SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS getFrameImage2 %d"), iImage);
-                        if (RenderStreamLink::instance().rs_getFrameImage2(frameData.imageId, &data) != RenderStreamLink::RS_ERROR_SUCCESS)
-                        {
-
-                        }
+                        Texture->InitCustomFormat(frameData.width, frameData.height, EPixelFormat::PF_FloatRGBA, false);
                     }
                     else
                     {
-                        UE_LOG(LogRenderStream, Error, TEXT("RenderStream tried to send frame with unsupported RHI backend."));
-                        return;
+                        Texture->ResizeTarget(frameData.width, frameData.height);
                     }
-                });
 
-                const URenderStreamSettings* settings2 = GetDefault<URenderStreamSettings>();
-                if (settings2->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
-                {
-                    UTextureRenderTarget2D* tmpTexture = UKismetRenderingLibrary::CreateRenderTarget2D(
-                        Root->GetWorld(),
-                        Texture->SizeX,
-                        Texture->SizeY
+                    if (!m_textureColourTransform->bGPUSharedFlag || m_textureColourTransform->GetFormat() != formatMap[frameData.format].ue)
+                    {
+                        m_textureColourTransform->bGPUSharedFlag = true;
+                        m_textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
+                    }
+                    else
+                    {
+                        Texture->ResizeTarget(frameData.width, frameData.height);
+                    }
+
+                    FTextureRenderTargetResource* SourceRes = Texture->GameThread_GetRenderTargetResource();
+                    FTextureRenderTargetResource* DestRes = m_textureColourTransform->GameThread_GetRenderTargetResource();
+                    if (!SourceRes || !DestRes)
+                    {
+                        UE_LOG(LogRenderStream, Error, TEXT("Cannot get render target resource for a source or a destination"));
+                        continue;
+                    }
+
+                    FTextureRHIRef SourceTexture = SourceRes->GetRenderTargetTexture();
+                    FTextureRHIRef DestTexture = DestRes->GetRenderTargetTexture();
+                    if (!SourceTexture || !DestTexture)
+                    {
+                        UE_LOG(LogRenderStream, Error, TEXT("Cannot get render target texture for a source or a destination"));
+                        continue;
+                    }
+
+                    ENQUEUE_RENDER_COMMAND(CopyTex)(
+                        [SourceTexture, DestTexture](FRHICommandListImmediate& RHICmdList)
+                        {
+                            RHICmdList.CopyTexture(
+                                SourceTexture,
+                                DestTexture,
+                                FRHICopyTextureInfo()
+                            );
+                        }
                     );
 
-                    static FOpenColorIOColorConversionSettings ConvSettings;
-                    ConvSettings.ConfigurationSource = settings2->OCIOConfig.ColorConfiguration.ConfigurationSource;
-
-                    if (settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace.ColorSpaceIndex != INDEX_NONE)
-                    {
-                        ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace;
-                        ConvSettings.DestinationColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
-                    }
-                    else
-                    {
-                        ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
-                        ConvSettings.DestinationDisplayView = settings2->OCIOConfig.ColorConfiguration.DestinationDisplayView;
-                        ConvSettings.DisplayViewDirection = EOpenColorIOViewTransformDirection::Inverse;
-                    }
-                    
+                    GetTextureParameter(toggle, frameData, iImage, m_textureColourTransform);
 
                     bool isTransformApplied = UOpenColorIOBlueprintLibrary::ApplyColorSpaceTransform(
                         Root,
-                        ConvSettings,
-                        Texture,
-                        tmpTexture
+                        m_colourConversionSettings,
+                        m_textureColourTransform,
+                        Texture
                     );
 
                     if (!isTransformApplied)
                     {
-                        UE_LOG(LogRenderStream, Error, TEXT("Failed to apply colour transform"));
+                        UE_LOG(LogRenderStream, Error, TEXT("Failed to apply colour transform. If colour transform uses display-view, please check if 'Support inverse view transform' option is enabled in UE project"));
                     }
-
-                    //{
-                    //    TArray<FLinearColor> LinearDataTMP;
-                    //    tmpTexture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
-                    //    FString color = LinearDataTMP[0].ToString();
-                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: tmpTexture colour after = %s"), *color);
-                    //}
-
-                    Texture->InitCustomFormat(frameData.width, frameData.height, EPixelFormat::PF_FloatRGBA, false);
-
-                    //{
-                    //    TArray<FLinearColor> LinearDataTMP;
-                    //    Texture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
-                    //    FString color = LinearDataTMP[0].ToString();
-                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: Texture colour before = %s"), *color);
-                    //}
-
-                    UMaterialInterface* CopyMat = LoadObject<UMaterialInterface>(
-                        nullptr,
-                        TEXT("/Game/M_CopyRT.M_CopyRT")
-                    );
-
-                    if (CopyMat)
+                }
+                else
+                {
+                    if (!Texture->bGPUSharedFlag || Texture->GetFormat() != formatMap[frameData.format].ue)
                     {
-                        UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(CopyMat, Root);
-                        MID->SetTextureParameterValue(TEXT("InputTexture"), tmpTexture);
-                        UKismetRenderingLibrary::DrawMaterialToRenderTarget(Root->GetWorld(), Texture, MID);
+                        Texture->bGPUSharedFlag = true;
+                        Texture->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
                     }
                     else
                     {
-                        UE_LOG(LogRenderStream, Error, TEXT("Didn't find the material during the colour transform"));
+                        Texture->ResizeTarget(frameData.width, frameData.height);
                     }
 
-
-                    //{
-                    //    TArray<FLinearColor> LinearDataTMP;
-                    //    Texture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
-                    //    FString color = LinearDataTMP[0].ToString();
-                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: Texture colour after = %s"), *color);
-                    //}
+                    GetTextureParameter(toggle, frameData, iImage, Texture);
                 }
 
                 ++iImage;

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -14,17 +14,18 @@
 
 #include "ProfilingDebugging/RealtimeGPUProfiler.h"
 #include <Kismet/KismetRenderingLibrary.h>
-
-#include "Materials/MaterialInstanceDynamic.h"
 #include "OpenColorIOBlueprintLibrary.h"
-#include <OpenColorIOColorTransform.h>
-#include <OpenColorIORendering.h>
 
 RenderStreamSceneSelector::~RenderStreamSceneSelector()
 {
-    if (m_textureColourTransform && m_textureColourTransform->IsRooted())
+    if (m_textureColourTransform)
     {
-        m_textureColourTransform->RemoveFromRoot();
+        if (m_textureColourTransform->IsRooted())
+        {
+            m_textureColourTransform->RemoveFromRoot();
+        }
+
+        UKismetRenderingLibrary::ReleaseRenderTarget2D(m_textureColourTransform);
     }
 }
 
@@ -211,10 +212,15 @@ bool RenderStreamSceneSelector::ValidateParameters(const RenderStreamLink::Remot
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
     if (settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource)
     {
-        isColourConfigurationEnabled = true;
+        m_isColourConfigurationEnabled = true;
 
         m_colourConversionSettings.ConfigurationSource = settings->OCIOConfig.ColorConfiguration.ConfigurationSource;
 
+        // OCIO has two different types for colour space, ColorSpace and DisplayView.
+        // Colour transform of ColorSpace can be supported in any order; however, DisplayView cannot be used as a source.
+        // To use DisplayView as a source, `DisplayViewDirection` needs to be set to `Inverse` with
+        // `colourConversionSettings.DestinationDisplayView` set to `DestinationDisplayView`.
+        // `Support inverse view transform` setting under `Plugins - OpenColorIO` in the UE project must be enabled: DSOF-31260
         if (settings->OCIOConfig.ColorConfiguration.DestinationColorSpace.ColorSpaceIndex != INDEX_NONE)
         {
             m_colourConversionSettings.SourceColorSpace = settings->OCIOConfig.ColorConfiguration.DestinationColorSpace;
@@ -770,7 +776,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
 
                 const RenderStreamLink::ImageFrameData& frameData = imageValues[iImage];
 
-                if (isColourConfigurationEnabled)
+                if (m_isColourConfigurationEnabled)
                 {
                     if (!m_textureColourTransform)
                     {

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -423,14 +423,6 @@ size_t RenderStreamSceneSelector::ValidateParameters(const AActor* Root, RenderS
                     return SIZE_MAX;
                 }
                 validateField(Name, "", RenderStreamLink::RS_PARAMETER_IMAGE, parameters[nParameters]);
-
-                //m_textureColourTransform = UKismetRenderingLibrary::CreateRenderTarget2D(
-                //    Root->GetWorld(),
-                //    Texture->SizeX,
-                //    Texture->SizeY, 
-                //    Texture->RenderTargetFormat
-                //);
-
                 ++nParameters;
             }
             else

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -18,14 +18,17 @@
 
 RenderStreamSceneSelector::~RenderStreamSceneSelector()
 {
-    if (m_textureColourTransform)
+    for (UTextureRenderTarget2D* texture : m_texturesColourTransform)
     {
-        if (m_textureColourTransform->IsRooted())
+        if (texture)
         {
-            m_textureColourTransform->RemoveFromRoot();
-        }
+            if (texture->IsRooted())
+            {
+                texture->RemoveFromRoot();
+            }
 
-        UKismetRenderingLibrary::ReleaseRenderTarget2D(m_textureColourTransform);
+            UKismetRenderingLibrary::ReleaseRenderTarget2D(texture);
+        }
     }
 }
 
@@ -778,21 +781,24 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
 
                 if (m_isColourConfigurationEnabled)
                 {
-                    if (!m_textureColourTransform)
+                    if (iImage >= m_texturesColourTransform.size())
                     {
-                        m_textureColourTransform = UKismetRenderingLibrary::CreateRenderTarget2D(
+                        UTextureRenderTarget2D* texture = UKismetRenderingLibrary::CreateRenderTarget2D(
                             Root,
                             Texture->SizeX,
                             Texture->SizeY,
                             Texture->RenderTargetFormat
                         );
 
-                        m_textureColourTransform->SRGB = 0;
-                        m_textureColourTransform->bForceLinearGamma = true;
+                        texture->SRGB = 0;
+                        texture->bForceLinearGamma = true;
 
-                        m_textureColourTransform->AddToRoot();
-                        m_textureColourTransform->UpdateResourceImmediate(true);
+                        texture->AddToRoot();
+                        texture->UpdateResourceImmediate(true);
+
+                        m_texturesColourTransform.push_back(std::move(texture));
                     }
+                    UTextureRenderTarget2D* textureColourTransform = m_texturesColourTransform[iImage];
 
                     if (Texture->OverrideFormat != EPixelFormat::PF_FloatRGBA)
                     {
@@ -803,49 +809,22 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                         Texture->ResizeTarget(frameData.width, frameData.height);
                     }
 
-                    if (!m_textureColourTransform->bGPUSharedFlag || m_textureColourTransform->GetFormat() != formatMap[frameData.format].ue)
+                    if (!textureColourTransform->bGPUSharedFlag || textureColourTransform->GetFormat() != formatMap[frameData.format].ue)
                     {
-                        m_textureColourTransform->bGPUSharedFlag = true;
-                        m_textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
+                        textureColourTransform->bGPUSharedFlag = true;
+                        textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
                     }
                     else
                     {
-                        Texture->ResizeTarget(frameData.width, frameData.height);
+                        textureColourTransform->ResizeTarget(frameData.width, frameData.height);
                     }
 
-                    FTextureRenderTargetResource* SourceRes = Texture->GameThread_GetRenderTargetResource();
-                    FTextureRenderTargetResource* DestRes = m_textureColourTransform->GameThread_GetRenderTargetResource();
-                    if (!SourceRes || !DestRes)
-                    {
-                        UE_LOG(LogRenderStream, Error, TEXT("Cannot get render target resource for a source or a destination"));
-                        continue;
-                    }
-
-                    FTextureRHIRef SourceTexture = SourceRes->GetRenderTargetTexture();
-                    FTextureRHIRef DestTexture = DestRes->GetRenderTargetTexture();
-                    if (!SourceTexture || !DestTexture)
-                    {
-                        UE_LOG(LogRenderStream, Error, TEXT("Cannot get render target texture for a source or a destination"));
-                        continue;
-                    }
-
-                    ENQUEUE_RENDER_COMMAND(CopyTex)(
-                        [SourceTexture, DestTexture](FRHICommandListImmediate& RHICmdList)
-                        {
-                            RHICmdList.CopyTexture(
-                                SourceTexture,
-                                DestTexture,
-                                FRHICopyTextureInfo()
-                            );
-                        }
-                    );
-
-                    GetTextureParameter(toggle, frameData, iImage, m_textureColourTransform);
+                    GetTextureParameter(toggle, frameData, iImage, textureColourTransform);
 
                     bool isTransformApplied = UOpenColorIOBlueprintLibrary::ApplyColorSpaceTransform(
                         Root,
                         m_colourConversionSettings,
-                        m_textureColourTransform,
+                        textureColourTransform,
                         Texture
                     );
 

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -804,7 +804,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     {
                         Texture->InitCustomFormat(frameData.width, frameData.height, EPixelFormat::PF_FloatRGBA, false);
                     }
-                    else
+                    else if (Texture->SizeX != frameData.width || Texture->SizeY != frameData.height)
                     {
                         Texture->ResizeTarget(frameData.width, frameData.height);
                     }
@@ -814,7 +814,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                         textureColourTransform->bGPUSharedFlag = true;
                         textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
                     }
-                    else
+                    else if (textureColourTransform->SizeX != frameData.width || textureColourTransform->SizeY != frameData.height)
                     {
                         textureColourTransform->ResizeTarget(frameData.width, frameData.height);
                     }
@@ -840,7 +840,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                         Texture->bGPUSharedFlag = true;
                         Texture->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
                     }
-                    else
+                    else if (Texture->SizeX != frameData.width || Texture->SizeY != frameData.height)
                     {
                         Texture->ResizeTarget(frameData.width, frameData.height);
                     }

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -13,6 +13,10 @@
 #include "TextureResource.h"
 
 #include "ProfilingDebugging/RealtimeGPUProfiler.h"
+#include <Kismet/KismetRenderingLibrary.h>
+
+#include "Materials/MaterialInstanceDynamic.h"
+#include "OpenColorIOBlueprintLibrary.h"
 
 RenderStreamSceneSelector::~RenderStreamSceneSelector() = default;
 
@@ -741,6 +745,47 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                         return;
                     }
                 });
+
+                UTextureRenderTarget2D* tmpTexture = UKismetRenderingLibrary::CreateRenderTarget2D(
+                    Root->GetWorld(),
+                    Texture->SizeX,
+                    Texture->SizeY
+                );
+
+                const URenderStreamSettings* settings2 = GetDefault<URenderStreamSettings>();
+                if (settings2->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+                {
+                    FOpenColorIOColorConversionSettings ConvSettings;
+                    ConvSettings.ConfigurationSource = settings2->OCIOConfig.ColorConfiguration.ConfigurationSource;
+                    // NOTE: I reverted the source/destination color spaces on purpose
+                    // since we need to transform the shared texture parameter in the opposite way we do the viewport
+                    ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace;
+                    ConvSettings.DestinationColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
+
+                    UOpenColorIOBlueprintLibrary::ApplyColorSpaceTransform(
+                        Root, 
+                        ConvSettings,    
+                        Texture,
+                        tmpTexture 
+                    );
+
+                    UMaterialInterface* CopyMat = LoadObject<UMaterialInterface>(
+                        nullptr,
+                        TEXT("/Game/M_CopyRT.M_CopyRT")
+                    );
+
+                    if (CopyMat)
+                    {
+                        UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(CopyMat, GetTransientPackage());
+                        MID->SetTextureParameterValue(TEXT("InputTexture"), tmpTexture);
+                        UKismetRenderingLibrary::DrawMaterialToRenderTarget(Root->GetWorld(), Texture, MID);
+                    }
+                    else
+                    {
+                        UE_LOG(LogRenderStream, Error, TEXT("Didn't find the material during the colour transform"));
+                    }
+                }
+
                 ++iImage;
             }
         }

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -550,7 +550,7 @@ void RenderStreamSceneSelector::GetTextureParameter(const FString& toggle, const
     ENQUEUE_RENDER_COMMAND(GetTex)(
         [Texture, toggle, frameData, iImage](FRHICommandListImmediate& RHICmdList)
         {
-            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Tex Param Block %d"), iImage);
+            SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Texture Parameter Block %d"), iImage);
             const auto rtResource = Texture->GetRenderTargetResource();
             if (!rtResource)
             {
@@ -762,7 +762,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
             {
                 if (iImage >= nImageVals)
                 {
-                    UE_LOG(LogRenderStream, Verbose, TEXT("Attempt to read a image value from disguise that is out of range. Does the metadata need to be regenerated?"));
+                    UE_LOG(LogRenderStream, Verbose, TEXT("Attempt to read an image value from disguise that is out of range. Does the metadata need to be regenerated?"));
                     continue;
                 }
 

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -396,6 +396,14 @@ size_t RenderStreamSceneSelector::ValidateParameters(const AActor* Root, RenderS
                     return SIZE_MAX;
                 }
                 validateField(Name, "", RenderStreamLink::RS_PARAMETER_IMAGE, parameters[nParameters]);
+
+                //m_textureColourTransform = UKismetRenderingLibrary::CreateRenderTarget2D(
+                //    Root->GetWorld(),
+                //    Texture->SizeX,
+                //    Texture->SizeY, 
+                //    Texture->RenderTargetFormat
+                //);
+
                 ++nParameters;
             }
             else
@@ -785,6 +793,22 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                         UE_LOG(LogRenderStream, Error, TEXT("Failed to apply colour transform"));
                     }
 
+                    //{
+                    //    TArray<FLinearColor> LinearDataTMP;
+                    //    tmpTexture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
+                    //    FString color = LinearDataTMP[0].ToString();
+                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: tmpTexture colour after = %s"), *color);
+                    //}
+
+                    Texture->InitCustomFormat(frameData.width, frameData.height, EPixelFormat::PF_FloatRGBA, false);
+
+                    //{
+                    //    TArray<FLinearColor> LinearDataTMP;
+                    //    Texture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
+                    //    FString color = LinearDataTMP[0].ToString();
+                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: Texture colour before = %s"), *color);
+                    //}
+
                     UMaterialInterface* CopyMat = LoadObject<UMaterialInterface>(
                         nullptr,
                         TEXT("/Game/M_CopyRT.M_CopyRT")
@@ -800,6 +824,14 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     {
                         UE_LOG(LogRenderStream, Error, TEXT("Didn't find the material during the colour transform"));
                     }
+
+
+                    //{
+                    //    TArray<FLinearColor> LinearDataTMP;
+                    //    Texture->GameThread_GetRenderTargetResource()->ReadLinearColorPixels(LinearDataTMP);
+                    //    FString color = LinearDataTMP[0].ToString();
+                    //    UE_LOG(LogRenderStream, Error, TEXT("AE_LOGS: Texture colour after = %s"), *color);
+                    //}
                 }
 
                 ++iImage;

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -17,6 +17,8 @@
 
 #include "Materials/MaterialInstanceDynamic.h"
 #include "OpenColorIOBlueprintLibrary.h"
+#include <OpenColorIOColorTransform.h>
+#include <OpenColorIORendering.h>
 
 RenderStreamSceneSelector::~RenderStreamSceneSelector() = default;
 
@@ -746,28 +748,42 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     }
                 });
 
-                UTextureRenderTarget2D* tmpTexture = UKismetRenderingLibrary::CreateRenderTarget2D(
-                    Root->GetWorld(),
-                    Texture->SizeX,
-                    Texture->SizeY
-                );
-
                 const URenderStreamSettings* settings2 = GetDefault<URenderStreamSettings>();
                 if (settings2->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
                 {
-                    FOpenColorIOColorConversionSettings ConvSettings;
-                    ConvSettings.ConfigurationSource = settings2->OCIOConfig.ColorConfiguration.ConfigurationSource;
-                    // NOTE: I reverted the source/destination color spaces on purpose
-                    // since we need to transform the shared texture parameter in the opposite way we do the viewport
-                    ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace;
-                    ConvSettings.DestinationColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
-
-                    UOpenColorIOBlueprintLibrary::ApplyColorSpaceTransform(
-                        Root, 
-                        ConvSettings,    
-                        Texture,
-                        tmpTexture 
+                    UTextureRenderTarget2D* tmpTexture = UKismetRenderingLibrary::CreateRenderTarget2D(
+                        Root->GetWorld(),
+                        Texture->SizeX,
+                        Texture->SizeY
                     );
+
+                    static FOpenColorIOColorConversionSettings ConvSettings;
+                    ConvSettings.ConfigurationSource = settings2->OCIOConfig.ColorConfiguration.ConfigurationSource;
+
+                    if (settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace.ColorSpaceIndex != INDEX_NONE)
+                    {
+                        ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.DestinationColorSpace;
+                        ConvSettings.DestinationColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
+                    }
+                    else
+                    {
+                        ConvSettings.SourceColorSpace = settings2->OCIOConfig.ColorConfiguration.SourceColorSpace;
+                        ConvSettings.DestinationDisplayView = settings2->OCIOConfig.ColorConfiguration.DestinationDisplayView;
+                        ConvSettings.DisplayViewDirection = EOpenColorIOViewTransformDirection::Inverse;
+                    }
+                    
+
+                    bool isTransformApplied = UOpenColorIOBlueprintLibrary::ApplyColorSpaceTransform(
+                        Root,
+                        ConvSettings,
+                        Texture,
+                        tmpTexture
+                    );
+
+                    if (!isTransformApplied)
+                    {
+                        UE_LOG(LogRenderStream, Error, TEXT("Failed to apply colour transform"));
+                    }
 
                     UMaterialInterface* CopyMat = LoadObject<UMaterialInterface>(
                         nullptr,
@@ -776,7 +792,7 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
 
                     if (CopyMat)
                     {
-                        UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(CopyMat, GetTransientPackage());
+                        UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(CopyMat, Root);
                         MID->SetTextureParameterValue(TEXT("InputTexture"), tmpTexture);
                         UKismetRenderingLibrary::DrawMaterialToRenderTarget(Root->GetWorld(), Texture, MID);
                     }

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -38,11 +38,15 @@ private:
     size_t ValidateParameters(const AActor* Root, RenderStreamLink::RemoteParameter* const parameters, size_t numParameters) const;
     void ApplyParameters(AActor* Root, uint64_t specHash, const RenderStreamLink::RemoteParameter** ppParams, const size_t nParams, const std::vector<float>& floatValues, size_t& iFloat, const RenderStreamLink::ImageFrameData** ppImageValues, const size_t nImageVals, size_t& nTextVals);
     void ApplySkeletalPose(uint64_t specHash, size_t iPose, const FString& ParamKey, RenderStreamLink::FAnimDataKey& PropKey);
+
+    void GetTextureParameter(const FString& toggle, const RenderStreamLink::ImageFrameData& frameData, size_t iImage, UTextureRenderTarget2D* Texture);
     
     TMap<uint64_t /*id*/, RenderStreamLink::FSkeletalLayout> m_skeletalLayoutCache;
     std::vector<uint8_t> m_schemaMem;
     RenderStreamLink::ScopedSchema m_defaultSchema;
     std::vector<float> m_floatValuesLast;
 
-    //mutable UTextureRenderTarget2D* m_textureColourTransform;
+    UTextureRenderTarget2D* m_textureColourTransform;
+    mutable FOpenColorIOColorConversionSettings m_colourConversionSettings;
+    mutable bool isColourConfigurationEnabled = false;
 };

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -46,7 +46,7 @@ private:
     RenderStreamLink::ScopedSchema m_defaultSchema;
     std::vector<float> m_floatValuesLast;
 
-    UTextureRenderTarget2D* m_textureColourTransform;
+    std::vector<UTextureRenderTarget2D*> m_texturesColourTransform;
     mutable FOpenColorIOColorConversionSettings m_colourConversionSettings;
     mutable bool m_isColourConfigurationEnabled = false;
 };

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -48,5 +48,5 @@ private:
 
     UTextureRenderTarget2D* m_textureColourTransform;
     mutable FOpenColorIOColorConversionSettings m_colourConversionSettings;
-    mutable bool isColourConfigurationEnabled = false;
+    mutable bool m_isColourConfigurationEnabled = false;
 };

--- a/Source/RenderStream/Public/RenderStreamSceneSelector.h
+++ b/Source/RenderStream/Public/RenderStreamSceneSelector.h
@@ -43,4 +43,6 @@ private:
     std::vector<uint8_t> m_schemaMem;
     RenderStreamLink::ScopedSchema m_defaultSchema;
     std::vector<float> m_floatValuesLast;
+
+    //mutable UTextureRenderTarget2D* m_textureColourTransform;
 };


### PR DESCRIPTION
[DSOF-31260](https://d3technologies.atlassian.net/browse/DSOF-31260)

**Bug Description:**
We didn't support texture parameter colour transform, including HDR colours. Changes for this ticket implement it. 

**Resolution Details:**
This ticket consists of 2 parts: UE plugin changes (this PR) and d3 changes ([that PR](https://github.com/disguise-one/d3/pull/5174).)

The current flow of the texture param colour transform looks like:

1. When sending texture param from d3, create a new output colour space, that would match the "Input transform" of the UE project (d3 related changes in a different PR.)
2. When receiving a frame in UE plugin, we use a second RenderTarget-helper of a format that supports texture stitching, while setting the original Texture's to a format that supports HDR colours (`EPixelFormat::PF_FloatRGBA`).
3. ~Copy the original UE provided Texture into the RenderTarget helper.~(Don't need this step actually.)
4. Copy the texture parameter into the RenderTarget helper.
5. Apply the colour transform from the helper to the final UE Texture.

Original flow with no colour transform remained unchanged, I only refactored some code.

Note:
During final testing I had a problem with workload crashing after running for a minute. I was able to resolve it after adding the new RenderTarget helper object to the Root. This allows to protect the object form the Garbage Collector, which is crucial since it's also used in the Render thread.

**Notes For QA:**
The ticket should be reproducible with the files and steps to reproduce that Effy mentioned. The only additional step is to enable `Support inverse view transform` setting under `Plugins - OpenColorIO` in the UE project.

The change includes 2 parts: d3 and UE plugin changes. The fix works only with the correct version of both.

Along with the correct colour transformation, please check if the RS workload is stable. 

[DSOF-31260]: https://d3technologies.atlassian.net/browse/DSOF-31260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ