### PR TITLE
OCIO Is Enabled tick box doesn't actually disable OCIO when unticked

### DIFF
--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -781,10 +781,13 @@ void FRenderStreamModule::OnBeginFrame()
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
 
     ADisplayClusterRootActor* const RootActor = IDisplayCluster::Get().GetGameMgr()->GetRootActor();
-    if (RootActor && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+    if (RootActor)
     {
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = true;
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = settings->OCIOConfig.bIsEnabled;
+        if(settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+        {
+           RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        }
     }
 }
 


### PR DESCRIPTION
[RSP-383](https://d3technologies.atlassian.net/browse/RSP-383)

### **Technical Description**

To check if OCIO is enabled the plugin checks if there is a valid config available. So when the tick box is unticked, OCIO is still enabled because the config is not deleted.

### **Solution**

Actually set the OCIO nDisplay setting to be disabled. Check the RenderStream bIsEnabled setting rather than just relying on if there is a valid config.

[RSP-383]: https://d3technologies.atlassian.net/browse/RSP-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ