### PR TITLE
RSP-383 5.5 Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# RS2.0-UE5.3-v8
+Compatible with disguise designer version r25.0 and above.
+* Fixed compatibility issue with the SonyCameraAndDisplay plugin
+
+# RS2.0-UE5.3-v7
+Compatible with disguise designer version r25.0 and above.
+* Fixed issue with custom events not being triggered when used in sublevels
+
 # RS2.0-UE5.3-v6
 Compatible with disguise designer version r25.0 and above.
 * Added more profiling granularity to certain functions

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -781,10 +781,13 @@ void FRenderStreamModule::OnBeginFrame()
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
 
     ADisplayClusterRootActor* const RootActor = IDisplayCluster::Get().GetGameMgr()->GetRootActor();
-    if (RootActor && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+    if (RootActor)
     {
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = true;
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = settings->OCIOConfig.bIsEnabled;
+        if(settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+        {
+           RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        }
     }
 }
 

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v6"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v7"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v7"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v8"
 
 class RenderStreamLink
 {


### PR DESCRIPTION
The 5.5 port of [RSP-383](https://d3technologies.atlassian.net/browse/RSP-383) approved in this [PR](https://github.com/disguise-one/RenderStream-UE/pull/121)

[RSP-383]: https://d3technologies.atlassian.net/browse/RSP-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ