### PR TITLE
RSP-383 5.6 Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# RS2.0-UE5.3-v8
+Compatible with disguise designer version r25.0 and above.
+* Fixed compatibility issue with the SonyCameraAndDisplay plugin
+
+# RS2.0-UE5.3-v7
+Compatible with disguise designer version r25.0 and above.
+* Fixed issue with custom events not being triggered when used in sublevels
+
 # RS2.0-UE5.3-v6
 Compatible with disguise designer version r25.0 and above.
 * Added more profiling granularity to certain functions

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -781,10 +781,13 @@ void FRenderStreamModule::OnBeginFrame()
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
 
     ADisplayClusterRootActor* const RootActor = IDisplayCluster::Get().GetGameMgr()->GetRootActor();
-    if (RootActor && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+    if (RootActor)
     {
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = true;
-        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.bIsEnabled = settings->OCIOConfig.bIsEnabled;
+        if(settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr)
+        {
+           RootActor->GetConfigData()->StageSettings.ViewportOCIO.AllViewportsOCIOConfiguration.ColorConfiguration = settings->OCIOConfig.ColorConfiguration;
+        }
     }
 }
 

--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -793,7 +793,7 @@ void FRenderStreamModule::OnBeginFrame()
     // OCIO needs 2 things at runtime: compiled shader and the proper LUT textures
     // Calling GetRenderPassResources allows us to retrieve a compiled shader and the neccessary textures
     // We want to cache these because we want to avoid Unreal's default application of OCIO which is bugged as of 5.6
-    if (settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr && GWorld && GWorld->Scene)
+    if (settings->OCIOConfig.bIsEnabled && settings->OCIOConfig.ColorConfiguration.ConfigurationSource != nullptr && GWorld && GWorld->Scene)
     {
         // Feature level refers to the shader model (SM5, SM6, etc.)
         const ERHIFeatureLevel::Type FeatureLevel = GWorld->Scene->GetFeatureLevel();

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v6"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.4-v7"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v2"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v3"
 
 class RenderStreamLink
 {

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v7"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.3-v8"
 
 class RenderStreamLink
 {


### PR DESCRIPTION
[RSP-383](https://d3technologies.atlassian.net/browse/RSP-383)

### Technical Description

When unticking the enable tick box in the RenderStream OCIO settings it doesn't actually disable OCIO. This is because the only thing the plugin checks to see if it should use OCIO is if there is a valid config. This does not get deleted when disabling OCIO leading it being always on. With the OCIO workaround introduced in 5.6 the logic for this and later versions are slightly different. Since we don't worry about setting the nDisplay OCIO config anymore the logic becomes simpler. Instead all we need to do to enforce the enable tick box setting is to add a check for bIsEnabled before caching any OCIO resources.

[RSP-383]: https://d3technologies.atlassian.net/browse/RSP-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ