### PR TITLE
RS Local texture parameters latency improvements

### DIFF
--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -183,16 +183,38 @@ void FRenderStreamModule::StartupModule()
 
     // This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
 
-    if (!RenderStreamLink::instance().loadExplicit())
+    FString loadError;
+    if (!RenderStreamLink::instance().loadExplicit(loadError))
     {
-        UE_LOG(LogRenderStream, Error, TEXT ("Failed to load RenderStream DLL - d3 not installed?"));
+        if (loadError.IsEmpty())
+        {
+            UE_LOG(LogRenderStream, Error, TEXT("Failed to load RenderStream DLL - d3 not installed?"));
+        }
+        else
+        {
+            if (RenderStreamLink::instance().rs_initialise)
+            {
+                int errCode = RenderStreamLink::instance().rs_initialise(RENDER_STREAM_VERSION_MAJOR, RENDER_STREAM_VERSION_MINOR);
+                if (errCode == RenderStreamLink::RS_ERROR_SUCCESS)
+                {
+                    FString msg = FString::Printf(TEXT("Failed to load %s from RenderStream DLL - d3 version is incompatible with this plugin version. Please update d3 or use an older plugin version"), *loadError);
+                    if (RenderStreamLink::instance().rs_logToD3)
+                        RenderStreamLink::instance().rs_logToD3(TCHAR_TO_ANSI(*msg));
+                }
+            }
+            if (!GIsEditor)
+            {
+                FPlatformMisc::RequestExit(true);
+            }
+            return;
+        }
     }
     else
     {
         m_logDevice = MakeShared<FRenderStreamLogOutputDevice, ESPMode::ThreadSafe>();
-        
+
         int errCode = RenderStreamLink::instance().rs_initialise(RENDER_STREAM_VERSION_MAJOR, RENDER_STREAM_VERSION_MINOR);
-        
+
         if (errCode != RenderStreamLink::RS_ERROR_SUCCESS)
         {
             if (errCode == RenderStreamLink::RS_ERROR_INCOMPATIBLE_VERSION)
@@ -206,7 +228,7 @@ void FRenderStreamModule::StartupModule()
             RenderStreamLink::instance().unloadExplicit();
             return;
         }
-        
+
         FCoreDelegates::OnHandleSystemError.AddRaw(this, &FRenderStreamModule::OnSystemError);
 
         FCoreUObjectDelegates::PostLoadMapWithWorld.AddRaw(this, &FRenderStreamModule::OnPostLoadMapWithWorld);

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -197,6 +197,7 @@ bool RenderStreamLink::loadExplicit()
     LOAD_FN(rs_getFrameParameters);
     LOAD_FN(rs_getFrameImageData);
     LOAD_FN(rs_getFrameImage2);
+    LOAD_FN(rs_registerTextureParams);
     LOAD_FN(rs_getFrameText);
 
     LOAD_FN(rs_getSkeletonLayout);

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -74,8 +74,8 @@ namespace {
 
 RenderStreamLink::RenderStreamLink()
 {
-    FString unused;
-    loadExplicit(unused);
+    FString outError;
+    loadExplicit(outError);
 }
 
 RenderStreamLink::~RenderStreamLink()

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -74,7 +74,8 @@ namespace {
 
 RenderStreamLink::RenderStreamLink()
 {
-    loadExplicit();
+    FString unused;
+    loadExplicit(unused);
 }
 
 RenderStreamLink::~RenderStreamLink()
@@ -87,8 +88,9 @@ bool RenderStreamLink::isAvailable()
     return m_dll && m_loaded;
 }
 
-bool RenderStreamLink::loadExplicit()
+bool RenderStreamLink::loadExplicit(FString& outError)
 {
+    outError.Empty();
     if (isAvailable())
         return true;
 
@@ -157,7 +159,7 @@ bool RenderStreamLink::loadExplicit()
             FString osMsg = e.message().c_str();
             UE_LOG(LogRenderStream, Error, TEXT("Failed to get function %s from DLL. %s (%i)"), fnName, *osMsg, e.value());
             m_loaded = false;
-            LogFatalIfNotInEditor("A function failed to load from the RenderStream DLL, this suggests an incompatible version is installed.");
+            outError = fnName;
             return false;
         }
         return true;
@@ -166,6 +168,8 @@ bool RenderStreamLink::loadExplicit()
 #define LOAD_FN(FUNC) \
     if (!loadFn(FUNC, TEXT(#FUNC))) \
         return false;
+
+
     
     LOAD_FN(rs_initialise);
     LOAD_FN(rs_initialiseGpGpuWithDX11Device);
@@ -174,6 +178,10 @@ bool RenderStreamLink::loadExplicit()
     LOAD_FN(rs_initialiseGpGpuWithVulkanDevice);
     LOAD_FN(rs_shutdown);
 
+    LOAD_FN(rs_logToD3);
+    LOAD_FN(rs_sendProfilingData);
+    LOAD_FN(rs_setNewStatusMessage);
+
     LOAD_FN(rs_registerLoggingFunc);
     LOAD_FN(rs_registerErrorLoggingFunc);
     LOAD_FN(rs_registerVerboseLoggingFunc);
@@ -181,6 +189,10 @@ bool RenderStreamLink::loadExplicit()
     LOAD_FN(rs_unregisterLoggingFunc);
     LOAD_FN(rs_unregisterErrorLoggingFunc);
     LOAD_FN(rs_unregisterVerboseLoggingFunc);
+
+    rs_registerLoggingFunc(&log_default);
+    rs_registerErrorLoggingFunc(&log_error);
+    rs_registerVerboseLoggingFunc(&log_verbose);
 
     LOAD_FN(rs_useDX12SharedHeapFlag);
 
@@ -198,6 +210,7 @@ bool RenderStreamLink::loadExplicit()
     LOAD_FN(rs_getFrameImageData);
     LOAD_FN(rs_getFrameImage2);
     LOAD_FN(rs_registerTextureParams);
+
     LOAD_FN(rs_getFrameText);
 
     LOAD_FN(rs_getSkeletonLayout);
@@ -209,15 +222,9 @@ bool RenderStreamLink::loadExplicit()
 
     LOAD_FN(rs_releaseImage2);
 
-    LOAD_FN(rs_logToD3);
-    LOAD_FN(rs_sendProfilingData);
-    LOAD_FN(rs_setNewStatusMessage);
 
     m_loaded = true;
 
-    rs_registerLoggingFunc(&log_default);
-    rs_registerErrorLoggingFunc(&log_error);
-    rs_registerVerboseLoggingFunc(&log_verbose);
 
 #endif
 

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -15,6 +15,7 @@
 #include "ProfilingDebugging/RealtimeGPUProfiler.h"
 #include <Kismet/KismetRenderingLibrary.h>
 #include "OpenColorIOBlueprintLibrary.h"
+#include "RenderingThread.h"
 
 RenderStreamSceneSelector::~RenderStreamSceneSelector()
 {
@@ -525,6 +526,13 @@ void RenderStreamSceneSelector::ApplyParameters(uint32_t sceneId, const TArray<A
     {
         UE_LOG(LogRenderStream, Error, TEXT("Unable to get float frame parameters - %d"), res);
         return;
+    }
+    if (nImageParams > 0)
+    {
+        ENQUEUE_RENDER_COMMAND(RegisterTextureParams)([](FRHICommandListImmediate& RHICmdList) {
+            RenderStreamLink::instance().rs_registerTextureParams();
+        });
+        FlushRenderingCommands();
     }
     res = RenderStreamLink::instance().rs_getFrameImageData(params.hash, imageValues.data(), imageValues.size());
     if (res != RenderStreamLink::RS_ERROR_SUCCESS)

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -468,7 +468,7 @@ private:
 public:
     RENDERSTREAM_API bool isAvailable();
 
-    bool loadExplicit();
+    bool loadExplicit(FString& outError);
     bool unloadExplicit();
 
     struct ScopedSchema

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -449,6 +449,7 @@ private:
     typedef RS_ERROR rs_getFrameParametersFn(uint64_t schemaHash, /*Out*/void* outParameterData, uint64_t outParameterDataSize);  // returns the remote parameters for this frame.
     typedef RS_ERROR rs_getFrameImageDataFn(uint64_t schemaHash, /*Out*/ImageFrameData* outParameterData, uint64_t outParameterDataCount);  // returns the remote image data for this frame.
     typedef RS_ERROR rs_getFrameImageFn(int64_t imageId, /*InOut*/const SenderFrame* data); // fills in (data) with the remote image
+    typedef RS_ERROR rs_registerTextureParamsFn(); // processes texture parameter registrations, must be called from a render thread
     typedef RS_ERROR rs_getFrameTextFn(uint64_t schemaHash, uint32_t textParamIndex, /*Out*/const char** outTextPtr); // // returns the remote text data (pointer only valid until next rs_awaitFrameData)
     
     typedef RS_ERROR rs_getSkeletonLayoutFn(uint64_t schemaHash, uint64_t id, /*Out*/SkeletonLayout* layout, /*Out*/int* numJoints);
@@ -581,6 +582,7 @@ public: // d3renderstream.h API, but loaded dynamically.
     rs_getFrameParametersFn* rs_getFrameParameters = nullptr;
     rs_getFrameImageDataFn* rs_getFrameImageData = nullptr;
     rs_getFrameImageFn* rs_getFrameImage2 = nullptr;
+    rs_registerTextureParamsFn* rs_registerTextureParams = nullptr;
     rs_getFrameTextFn* rs_getFrameText = nullptr;
     rs_getSkeletonLayoutFn* rs_getSkeletonLayout = nullptr;
     rs_getSkeletonJointNamesFn* rs_getSkeletonJointNames = nullptr;


### PR DESCRIPTION
[DSOF-30790](https://d3technologies.atlassian.net/browse/DSOF-30790)

**Description:**
Texture parameters for RSL were reported to have a high latency, around 5-9 frames.

This PR consists of d3 changes in https://github.com/disguise-one/d3/pull/5933 and plugin changes in this PR.

There are 2 main changes in plugin:

- Creating new `rs_registerTextureParams()` API endpoint to read shared texture before using it. Must be called from the UE render thread.
- In case of running old d3 version + RS3.0 UE plugin , we'd like to log an error message explaining why workload has crashed. To achieve it, I made some changes to `RenderStream::StartupModule()` logic, so we cache the error, load `rs_logToD3` and show the message in d3before closing UE. 

[DSOF-30790]: https://d3technologies.atlassian.net/browse/DSOF-30790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ