### PR TITLE
RSP-391: Optimize idle GPU usage when not receiving frame requests

### DIFF
--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -781,6 +781,11 @@ void FRenderStreamModule::OnBeginFrame()
     if (IsController)
         m_syncFrame.ControllerReceive();
 
+    // Skip scene rendering entirely when idle (no frame requests from disguise).
+    // This is the main GPU savings — prevents UE from rendering all nDisplay viewports.
+    if (GEngine && GEngine->GameViewport)
+        GEngine->GameViewport->bDisableWorldRendering = !m_syncFrame.m_frameDataValid;
+
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
 
     ADisplayClusterRootActor* const RootActor = IDisplayCluster::Get().GetGameMgr()->GetRootActor();

--- a/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
+++ b/Source/RenderStream/Private/RenderStreamCapturePostProcess.cpp
@@ -84,12 +84,7 @@ void FRenderStreamCapturePostProcess::PerformPostProcessViewAfterWarpBlend_Rende
             }
             else
             {
-                // default values to avoid any math assertions in debug dlls
-                frameResponse.camera.nearZ = 0.1f;
-                frameResponse.camera.farZ = 1.f;
-                frameResponse.camera.sensorX = 1.f;
-                frameResponse.camera.sensorY = 1.f;
-                frameResponse.camera.focalLength = 1.f;
+                return; // No frame requested — skip GPU blit, RHI flush, and rs_sendFrame2
             }
         }
 

--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -118,6 +118,9 @@ void FRenderStreamSyncFrameData::ControllerReceive()
         {
             TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive() - timeout, setting new status message"));
             RenderStreamLink::instance().rs_setNewStatusMessage("Not requested");
+            // Throttle rendering while idle: set a large delta so UE doesn't run
+            // catch-up ticks for the time spent blocking in rs_awaitFrameData.
+            FApp::SetFixedDeltaTime(FPlatformTime::Seconds() - StartTime);
         }
         else
         {

--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -118,9 +118,6 @@ void FRenderStreamSyncFrameData::ControllerReceive()
         {
             TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::ControllerReceive() - timeout, setting new status message"));
             RenderStreamLink::instance().rs_setNewStatusMessage("Not requested");
-            // Throttle rendering while idle: set a large delta so UE doesn't run
-            // catch-up ticks for the time spent blocking in rs_awaitFrameData.
-            FApp::SetFixedDeltaTime(FPlatformTime::Seconds() - StartTime);
         }
         else
         {


### PR DESCRIPTION
Skip scene rendering, capture pipeline, and catch-up ticks when disguise is not requesting frames, freeing GPU resources for other engines (e.g. Notch) sharing the same render nodes.

- Disable world rendering via bDisableWorldRendering when m_frameDataValid is false (main GPU savings)
- Early return in post-process when no frame response exists for the current render frame (skips blit/flush/sendFrame)
<img width="3463" height="1822" alt="UE_idle_workload_optimizations" src="https://github.com/user-attachments/assets/826d49ad-033c-4012-b772-4b2aaf03b828" />

