### PR TITLE
RSP-393: Duplicated camera names can cause inconsistent camera selection within cluster

### DIFF
--- a/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
+++ b/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
@@ -94,6 +94,34 @@ uint32 URenderStreamChannelDefinition::GetChannelCameraNum(const FString& Channe
     return (*Actors)->Num();
 }
 
+inline static TWeakObjectPtr<ACameraActor> GetBetterCamera(const TWeakObjectPtr<ACameraActor>& CamA, const TWeakObjectPtr<ACameraActor>& CamB)
+{
+    // prefer valid camera 
+    if (!CamB.IsValid())
+        return CamA;
+
+    if (!CamA.IsValid())
+        return CamB;
+
+    const bool CamAIsPersistent = CamA->GetLevel() && CamA->GetLevel()->IsPersistentLevel();
+    const bool CamBIsPersistent = CamB->GetLevel() && CamB->GetLevel()->IsPersistentLevel();
+
+    if (CamAIsPersistent != CamBIsPersistent)
+    {
+        // one is persistent, the other not: prefer the camera from the persistent level
+        if (CamAIsPersistent)
+            return CamA;
+        else
+            return CamB;
+    }
+
+    // final tiebreaker: prefer smaller path
+    if (CamA->GetPathName() < CamB->GetPathName())
+        return CamA;
+    else
+        return CamB;
+}
+
 TWeakObjectPtr<ACameraActor> URenderStreamChannelDefinition::GetChannelCamera(const FString& Channel)
 {
     if (Channel.IsEmpty())
@@ -111,25 +139,13 @@ TWeakObjectPtr<ACameraActor> URenderStreamChannelDefinition::GetChannelCamera(co
 
     // Select camera deterministically. BeginPlay() order is non-deterministic across
     // nDisplay cluster machines, so we cannot rely on array insertion order.
-    // Prefer persistent level cameras (the "primary" camera), then tiebreak by
-    // GetPathName() which is stable across machines since actor names and level
-    // paths are serialized in the packaged project.
     const auto& Cameras = *(*ActorsPtrPtr);
-    TWeakObjectPtr<ACameraActor> Best = Cameras[0];
-    bool BestIsPersistent = Best.IsValid() && Best->GetLevel() && Best->GetLevel()->IsPersistentLevel();
-    for (int32 i = 1; i < Cameras.Num(); i++)
+    TWeakObjectPtr<ACameraActor> Best;
+    for (const auto& Camera : Cameras)
     {
-        if (!Cameras[i].IsValid())
-            continue;
-        const bool CandidateIsPersistent = Cameras[i]->GetLevel() && Cameras[i]->GetLevel()->IsPersistentLevel();
-        if (!Best.IsValid()
-            || (CandidateIsPersistent && !BestIsPersistent)
-            || (CandidateIsPersistent == BestIsPersistent && Cameras[i]->GetPathName() < Best->GetPathName()))
-        {
-            Best = Cameras[i];
-            BestIsPersistent = CandidateIsPersistent;
-        }
+        Best = GetBetterCamera(Best, Camera);
     }
+
     return Best;
 }
 
@@ -263,11 +279,9 @@ void URenderStreamChannelDefinition::BeginPlay()
         if (Array.Num() > 0)
         {
             UE_LOG(LogRenderStreamChannelDefinition, Warning,
-                TEXT("Multiple cameras on channel '%s': '%s' already registered, now adding '%s'. "
+                TEXT("!!!!! Multiple cameras registered for the same channel '%s'. "
                      "This may cause non-deterministic camera selection across cluster nodes."),
-                *ChannelName,
-                Array.Last().IsValid() ? *Array.Last()->GetName() : TEXT("INVALID"),
-                *ActorName);
+                *ChannelName);
         }
         Array.Add(Owner);
         Registered = true;

--- a/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
+++ b/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
@@ -3,6 +3,7 @@
 #include "Camera/CameraActor.h"
 #include "Camera/CameraComponent.h"
 #include "Engine/GameEngine.h"
+#include "Engine/Level.h"
 #include "Kismet/GameplayStatics.h"
 
 DEFINE_LOG_CATEGORY(LogRenderStreamChannelDefinition);
@@ -108,17 +109,26 @@ TWeakObjectPtr<ACameraActor> URenderStreamChannelDefinition::GetChannelCamera(co
         return FindCameraInScene();
     }
 
-    // Select camera deterministically by lexicographically smallest path name.
-    // BeginPlay() order is non-deterministic across nDisplay cluster machines,
-    // so we cannot rely on array insertion order (i.e. Last() or First()).
-    // GetPathName() is stable across machines since actor names and level paths
-    // are serialized in the packaged project.
+    // Select camera deterministically. BeginPlay() order is non-deterministic across
+    // nDisplay cluster machines, so we cannot rely on array insertion order.
+    // Prefer persistent level cameras (the "primary" camera), then tiebreak by
+    // GetPathName() which is stable across machines since actor names and level
+    // paths are serialized in the packaged project.
     const auto& Cameras = *(*ActorsPtrPtr);
     TWeakObjectPtr<ACameraActor> Best = Cameras[0];
+    bool BestIsPersistent = Best.IsValid() && Best->GetLevel() && Best->GetLevel()->IsPersistentLevel();
     for (int32 i = 1; i < Cameras.Num(); i++)
     {
-        if (Cameras[i].IsValid() && (!Best.IsValid() || Cameras[i]->GetPathName() < Best->GetPathName()))
+        if (!Cameras[i].IsValid())
+            continue;
+        const bool CandidateIsPersistent = Cameras[i]->GetLevel() && Cameras[i]->GetLevel()->IsPersistentLevel();
+        if (!Best.IsValid()
+            || (CandidateIsPersistent && !BestIsPersistent)
+            || (CandidateIsPersistent == BestIsPersistent && Cameras[i]->GetPathName() < Best->GetPathName()))
+        {
             Best = Cameras[i];
+            BestIsPersistent = CandidateIsPersistent;
+        }
     }
     return Best;
 }

--- a/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
+++ b/Source/RenderStream/Private/RenderStreamChannelDefinition.cpp
@@ -108,7 +108,19 @@ TWeakObjectPtr<ACameraActor> URenderStreamChannelDefinition::GetChannelCamera(co
         return FindCameraInScene();
     }
 
-    return (*ActorsPtrPtr)->Last();
+    // Select camera deterministically by lexicographically smallest path name.
+    // BeginPlay() order is non-deterministic across nDisplay cluster machines,
+    // so we cannot rely on array insertion order (i.e. Last() or First()).
+    // GetPathName() is stable across machines since actor names and level paths
+    // are serialized in the packaged project.
+    const auto& Cameras = *(*ActorsPtrPtr);
+    TWeakObjectPtr<ACameraActor> Best = Cameras[0];
+    for (int32 i = 1; i < Cameras.Num(); i++)
+    {
+        if (Cameras[i].IsValid() && (!Best.IsValid() || Cameras[i]->GetPathName() < Best->GetPathName()))
+            Best = Cameras[i];
+    }
+    return Best;
 }
 
 URenderStreamChannelDefinition::URenderStreamChannelDefinition()
@@ -238,6 +250,15 @@ void URenderStreamChannelDefinition::BeginPlay()
         FString ActorName = GetOwner()->GetActorNameOrLabel();
         FString ChannelName = GetChannelName();
         auto& Array = FindOrAdd(ChannelActorMap, ChannelName);
+        if (Array.Num() > 0)
+        {
+            UE_LOG(LogRenderStreamChannelDefinition, Warning,
+                TEXT("Multiple cameras on channel '%s': '%s' already registered, now adding '%s'. "
+                     "This may cause non-deterministic camera selection across cluster nodes."),
+                *ChannelName,
+                Array.Last().IsValid() ? *Array.Last()->GetName() : TEXT("INVALID"),
+                *ActorName);
+        }
         Array.Add(Owner);
         Registered = true;
         UE_LOG(LogRenderStreamChannelDefinition, Log, TEXT("Adding camera '%s' to channel '%s'."), *ActorName, *ChannelName);

--- a/Source/RenderStream/Public/RenderStreamChannelCacheAsset.h
+++ b/Source/RenderStream/Public/RenderStreamChannelCacheAsset.h
@@ -87,4 +87,7 @@ public:
 
     UPROPERTY(EditAnywhere, Category = "ChannelCacheAsset")
     TMap<FString, FRenderStreamChannelInfo> ChannelInfoMap;
+
+    // Transient: populated during cache build, consumed by validation to detect same-level duplicates
+    TMap<FString, TArray<FString>> ChannelToActors;
 };

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -540,6 +540,7 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
     Cache->Level = LevelPath;
     Cache->Channels.Empty();
     Cache->ChannelInfoMap.Empty();
+    Cache->ChannelToActors.Empty();
     for (auto Actor : Level->Actors)
     {
         if (Actor)
@@ -548,16 +549,7 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
             if (Definition.IsValid())
             {
                 FString ChannelName = TCHAR_TO_UTF8(*(Definition->GetChannelName()));
-                // Detect duplicate channel names within this level. The cross-level case
-                // is handled separately in FRenderStreamValidation::RunValidation().
-                if (Cache->Channels.Contains(ChannelName))
-                {
-                    FMessageLog RSV("RenderStreamValidation");
-                    RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
-                        TEXT("Duplicate channel '%s' in level '%s': camera '%s' shares channel with another camera. "
-                             "Make sure camera names are unique."),
-                        *ChannelName, *LevelPath, *Actor->GetName()))));
-                }
+                Cache->ChannelToActors.FindOrAdd(ChannelName).Add(Actor->GetName());
                 Cache->Channels.Emplace(ChannelName);
                 FRenderStreamChannelInfo channelInfo = FRenderStreamValidation::GetChannelInfo(Definition, Level);
                 SanitizeChannelInfo(channelInfo);

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -40,6 +40,8 @@
 #include "FileHelpers.h"
 #include "GameMapsSettings.h"
 
+#include "Logging/MessageLog.h"
+#include "Misc/UObjectToken.h"
 #include "MessageLogInitializationOptions.h"
 #include "MessageLogModule.h"
 #include "IMessageLogListing.h"
@@ -546,6 +548,16 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
             if (Definition.IsValid())
             {
                 FString ChannelName = TCHAR_TO_UTF8(*(Definition->GetChannelName()));
+                // Detect duplicate channel names within this level. The cross-level case
+                // is handled separately in FRenderStreamValidation::RunValidation().
+                if (Cache->Channels.Contains(ChannelName))
+                {
+                    FMessageLog RSV("RenderStreamValidation");
+                    RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
+                        TEXT("Duplicate channel '%s' in level '%s': camera '%s' shares channel with another camera. "
+                             "This may cause non-deterministic camera selection across cluster nodes."),
+                        *ChannelName, *LevelPath, *Actor->GetName()))));
+                }
                 Cache->Channels.Emplace(ChannelName);
                 FRenderStreamChannelInfo channelInfo = FRenderStreamValidation::GetChannelInfo(Definition, Level);
                 SanitizeChannelInfo(channelInfo);

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -555,7 +555,7 @@ URenderStreamChannelCacheAsset* UpdateLevelChannelCache(ULevel* Level)
                     FMessageLog RSV("RenderStreamValidation");
                     RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
                         TEXT("Duplicate channel '%s' in level '%s': camera '%s' shares channel with another camera. "
-                             "This may cause non-deterministic camera selection across cluster nodes."),
+                             "Make sure camera names are unique."),
                         *ChannelName, *LevelPath, *Actor->GetName()))));
                 }
                 Cache->Channels.Emplace(ChannelName);

--- a/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
@@ -406,6 +406,36 @@ void FRenderStreamValidation::RunValidation(const TArray<URenderStreamChannelCac
     }
     IssuesFound |= ValidateProjectSettings();
 
+    // Detect duplicate channel names across different levels (e.g., a camera in the
+    // persistent level sharing a channel name with a camera in a streaming sub-level).
+    // Within-level duplicates are caught separately in UpdateLevelChannelCache().
+    TMap<FString, FString> ChannelToLevel;
+    for (const URenderStreamChannelCacheAsset* Cache : Caches)
+    {
+        if (!Cache)
+            continue;
+
+        const FString LevelName = Cache->GetName();
+
+        for (const FString& ChannelName : Cache->Channels)
+        {
+            if (const FString* ExistingLevel = ChannelToLevel.Find(ChannelName))
+            {
+                IssuesFound = true;
+                FMessageLog RSV("RenderStreamValidation");
+                RSV.SuppressLoggingToOutputLog(true);
+                RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
+                    TEXT("Channel '%s' exists in multiple levels: '%s' and '%s'. "
+                         "This may cause non-deterministic camera selection across cluster nodes."),
+                    *ChannelName, **ExistingLevel, *LevelName))));
+            }
+            else
+            {
+                ChannelToLevel.Add(ChannelName, LevelName);
+            }
+        }
+    }
+
     for (const URenderStreamChannelCacheAsset* Cache : Caches)
     {
         if (!Cache)

--- a/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
@@ -391,24 +391,35 @@ bool FRenderStreamValidation::ValidateChannelInfo(const FRenderStreamChannelInfo
     return IssuesFound;
 }
 
-void FRenderStreamValidation::RunValidation(const TArray<URenderStreamChannelCacheAsset*>& Caches)
+bool FRenderStreamValidation::ValidateDuplicateChannels(const TArray<URenderStreamChannelCacheAsset*>& Caches)
 {
     bool IssuesFound = false;
+
+    // Same-level duplicates: multiple cameras in one level sharing a channel name
+    for (const URenderStreamChannelCacheAsset* Cache : Caches)
     {
-        FMessageLog RSV("RenderStreamValidation");
-        RSV.SuppressLoggingToOutputLog(true);
-        RSV.Info()->AddToken(FTextToken::Create(FText::FromString("Project settings:")));
-        if (Caches.Num() == 0)
+        if (!Cache)
+            continue;
+
+        const FString LevelName = Cache->GetName();
+
+        for (const auto& Pair : Cache->ChannelToActors)
         {
-            IssuesFound = true;
-            RSV.Warning()->AddToken(FTextToken::Create(FText::FromString(FString(TEXT("Camera with a renderstream channel definition component not detected.")))));
+            if (Pair.Value.Num() > 1)
+            {
+                IssuesFound = true;
+                FMessageLog RSV("RenderStreamValidation");
+                RSV.SuppressLoggingToOutputLog(true);
+                FString ActorList = FString::Join(Pair.Value, TEXT("', '"));
+                RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
+                    TEXT("Duplicate channel '%s' in level '%s': cameras '%s' share the same channel name. "
+                         "Make sure camera names are unique."),
+                    *Pair.Key, *LevelName, *ActorList))));
+            }
         }
     }
-    IssuesFound |= ValidateProjectSettings();
 
-    // Detect duplicate channel names across different levels (e.g., a camera in the
-    // persistent level sharing a channel name with a camera in a streaming sub-level).
-    // Within-level duplicates are caught separately in UpdateLevelChannelCache().
+    // Cross-level duplicates: same channel name appearing in different levels
     TMap<FString, FString> ChannelToLevel;
     for (const URenderStreamChannelCacheAsset* Cache : Caches)
     {
@@ -435,6 +446,25 @@ void FRenderStreamValidation::RunValidation(const TArray<URenderStreamChannelCac
             }
         }
     }
+
+    return IssuesFound;
+}
+
+void FRenderStreamValidation::RunValidation(const TArray<URenderStreamChannelCacheAsset*>& Caches)
+{
+    bool IssuesFound = false;
+    {
+        FMessageLog RSV("RenderStreamValidation");
+        RSV.SuppressLoggingToOutputLog(true);
+        RSV.Info()->AddToken(FTextToken::Create(FText::FromString("Project settings:")));
+        if (Caches.Num() == 0)
+        {
+            IssuesFound = true;
+            RSV.Warning()->AddToken(FTextToken::Create(FText::FromString(FString(TEXT("Camera with a renderstream channel definition component not detected.")))));
+        }
+    }
+    IssuesFound |= ValidateProjectSettings();
+    IssuesFound |= ValidateDuplicateChannels(Caches);
 
     for (const URenderStreamChannelCacheAsset* Cache : Caches)
     {

--- a/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamValidation.cpp
@@ -426,7 +426,7 @@ void FRenderStreamValidation::RunValidation(const TArray<URenderStreamChannelCac
                 RSV.SuppressLoggingToOutputLog(true);
                 RSV.Error()->AddToken(FTextToken::Create(FText::FromString(FString::Printf(
                     TEXT("Channel '%s' exists in multiple levels: '%s' and '%s'. "
-                         "This may cause non-deterministic camera selection across cluster nodes."),
+                         "Make sure camera names are unique."),
                     *ChannelName, **ExistingLevel, *LevelName))));
             }
             else

--- a/Source/RenderStreamEditor/Public/RenderStreamValidation.h
+++ b/Source/RenderStreamEditor/Public/RenderStreamValidation.h
@@ -18,6 +18,7 @@ public:
     static FRenderStreamChannelInfo GetChannelInfo(TWeakObjectPtr<URenderStreamChannelDefinition> ChannelDefinition, const ULevel* Level);
     static bool ValidateChannelInfo(const FRenderStreamChannelInfo& Info, const FString& Level);
     static bool ValidateProjectSettings();
+    static bool ValidateDuplicateChannels(const TArray<URenderStreamChannelCacheAsset*>& Caches);
     static void RunValidation(const TArray<URenderStreamChannelCacheAsset*>& Caches);
     static void ForceRunValidation();
 };


### PR DESCRIPTION
### Technical Description:

When multiple cameras share the same RenderStream channel name (either within a single level or across streaming sub-levels), the camera selected at runtime was determined by BeginPlay() execution order. This order is non-deterministic across nDisplay cluster nodes, meaning different machines in the cluster could pick different cameras for the same channel, leading to inconsistent rendering.

### Solution:

Three changes were made:

Deterministic camera selection — Instead of using the last-registered camera (Array.Last()), the selection now sorts candidates by preferring cameras in the persistent level first, then tie-breaking by GetPathName() (which is stable across machines since actor/level paths are serialized in the packaged project).
Runtime warning — A log warning is emitted during BeginPlay() when a second camera registers on an already-occupied channel, alerting users to the duplicate.
Editor-time validation — Two new checks in the editor detect duplicate channel names: one within the same level (in UpdateLevelChannelCache) and one across different levels (in FRenderStreamValidation::RunValidation). Both report errors through the RenderStreamValidation message log.

### Affected areas:

RenderStreamChannelDefinition — camera selection logic and BeginPlay registration
RenderStreamEditorModule — level channel cache building
RenderStreamValidation — cross-level validation pass