### PR TITLE
Follower Node Does Not Exit Cleanly On Stop

### DIFF
--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -236,10 +236,6 @@ void FRenderStreamSyncFrameData::Apply() const
 void FRenderStreamSyncFrameData::QuitNow() const
 {
     TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::QuitNow()"));
-    if (IsEngineExitRequested())
-    {
-        return;
-    }
     RenderStreamLink::instance().rs_setNewStatusMessage("");
     UE_LOG(LogRenderStream, Log, TEXT("Quitting due to RenderStream request"));
     FPlatformMisc::RequestExit(false);

--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -27,6 +27,11 @@ FString FRenderStreamSyncFrameData::SerializeToString() const
 
 bool FRenderStreamSyncFrameData::DeserializeFromString(const FString& Str)
 {
+    if (IsEngineExitRequested())
+    {
+        return true;
+    }
+
     TArray<uint8> TempBytes;
     TempBytes.AddUninitialized(Str.Len());
     StringToBytes(Str, TempBytes.GetData(), Str.Len());
@@ -231,6 +236,10 @@ void FRenderStreamSyncFrameData::Apply() const
 void FRenderStreamSyncFrameData::QuitNow() const
 {
     TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::QuitNow()"));
+    if (IsEngineExitRequested())
+    {
+        return;
+    }
     RenderStreamLink::instance().rs_setNewStatusMessage("");
     UE_LOG(LogRenderStream, Log, TEXT("Quitting due to RenderStream request"));
     FPlatformMisc::RequestExit(false);


### PR DESCRIPTION
[RSP-396](https://d3technologies.atlassian.net/browse/RSP-396?atlOrigin=eyJpIjoiN2ViNDZkOTM1ZDQwNGQzYmI1MTc3M2FkYjliMjZlNGYiLCJwIjoiaiJ9)

## Summary

When running a workload with 2 or more machines and then hitting stop, the follower nodes will take longer and in the process spam logs about exit request. It's believed that due to this sometimes the process can fail to be killed resulting in a lingering ghost process. When a stop is requested the controller sets m_isQuitting = true, this also gets set on the follower node through DeserializeFromString(). The first time it's received it starts the engine shutdown sequence, however during this sequence DeserializeFromString() is still be called on the follower which does all the FollowerReceive logic again including calling the shutdown logic again. There is no check that there was already an exit request leading to the log spamming and potential shutdown issues.

## Solution

I have added a guard in DeserializeFromString() to check if an exit request has already been made. The idea here is that there's no point in going through with anymore deserialization after an exit request has been made.

[RSP-396]: https://d3technologies.atlassian.net/browse/RSP-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ