### PR TITLE
RSP-398 adding git action trigger

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure git
         run: |

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,54 @@
+name: Tag release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git
+        run: |
+          git config --local user.email "build@disguise.com"
+          git config --local user.name "CI"
+
+      - name: Create empty commit and tag, push atomically
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          BASE_SHA=$(git rev-parse --short HEAD)
+          TAG="Release_${BRANCH}_${BASE_SHA}"
+          MSG="(( ${TAG} ))"
+
+          echo "Branch:       $BRANCH"
+          echo "Base commit:  $BASE_SHA"
+          echo "Tag:          $TAG"
+          echo "Commit msg:   $MSG"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::tag ${TAG} already exists locally"; exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::tag ${TAG} already exists on origin"; exit 1
+          fi
+
+          git commit --allow-empty -m "$MSG"
+          git tag -a "$TAG" -m "$MSG"
+          git push --atomic origin "HEAD:refs/heads/${BRANCH}" "refs/tags/${TAG}"
+
+          {
+            echo "### Release tagged"
+            echo ""
+            echo "- **Branch:** \`$BRANCH\`"
+            echo "- **Base commit:** \`$BASE_SHA\`"
+            echo "- **Tag:** \`$TAG\`"
+            echo "- **Commit message:** \`$MSG\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/TC_env_setup.ps1
+++ b/TC_env_setup.ps1
@@ -136,12 +136,11 @@ if ($matchedTags)
     write-host "Tag detected: ", $finalTag, ". Will create draft Github Release"
 
     $github_token = get-github_app_token
-    write-host "GitHub App token begins:",$github_token.Substring(0,7)
 
     $headers = @{}
     $headers.Add('Authorization',"token $github_token")
     $headers.Add('Accept', 'application/vnd.github.v3+json')
-
+    $headers.Add('Content-Type','application/json')
     # Create new release for based on tag discovered
     # eg https://api.github.com/repos/octocat/hello-world/releases
 

--- a/TC_env_setup.ps1
+++ b/TC_env_setup.ps1
@@ -22,7 +22,41 @@ function select-UE_engine_from_json
 }
 
 
-function connect-network_drive{ param($server_ip) 
+function get-github_app_token {
+    # Runs the GitHub App token executable provided on the build agent and
+    # returns a short-lived installation access token. The exe path and the
+    # private key path are supplied via env vars set up by TeamCity.
+    Write-Host "Generating GitHub App token..."
+
+    $token_exe = $env:github_app_token_exe
+    $pem_path  = $env:github_app_pem
+
+    if (-not $token_exe -or -not (Test-Path $token_exe)) {
+        throw "github_app_token_exe is not set or does not exist: '$token_exe'"
+    }
+    if (-not $pem_path -or -not (Test-Path $pem_path)) {
+        throw "github_app_pem is not set or does not exist: '$pem_path'"
+    }
+
+    $raw = & $token_exe --pem $pem_path
+    if ($LASTEXITCODE -ne 0) {
+        throw "github app token exe failed with exit code $LASTEXITCODE"
+    }
+
+    $response = ($raw -join "`n").Trim() | ConvertFrom-Json
+
+    if ($response.status -ne 201) {
+        throw "Failed to get github app token. Status: $($response.status)"
+    }
+    if ([string]::IsNullOrEmpty($response.token)) {
+        throw "github app token exe returned an empty token"
+    }
+
+    return $response.token
+}
+
+
+function connect-network_drive{ param($server_ip)
 
     $engine_version = select-UE_engine_from_json
     
@@ -99,11 +133,13 @@ if ($matchedTags)
 {
     $finalTag = $matchedTags[0] -replace ".*\(\(\s+" -replace "\s+\)\).*"
 
-    write-host "Tag detected: ", $finalTag, " - creating Draft Github Release"
-    write-host "PAT from Team City begins:", $env:personal_access_token.Substring(0,7)
+    write-host "Tag detected: ", $tag, ". Will create draft Github Release"
+
+    $github_token = get-github_app_token
+    write-host "GitHub App token begins:",$github_token.Substring(0,7)
 
     $headers = @{}
-    $headers.Add('Authorization',"token $env:personal_access_token")
+    $headers.Add('Authorization',"token $github_token")
     $headers.Add('Accept', 'application/vnd.github.v3+json')
 
     # Create new release for based on tag discovered

--- a/TC_env_setup.ps1
+++ b/TC_env_setup.ps1
@@ -133,7 +133,7 @@ if ($matchedTags)
 {
     $finalTag = $matchedTags[0] -replace ".*\(\(\s+" -replace "\s+\)\).*"
 
-    write-host "Tag detected: ", $tag, ". Will create draft Github Release"
+    write-host "Tag detected: ", $finalTag, ". Will create draft Github Release"
 
     $github_token = get-github_app_token
     write-host "GitHub App token begins:",$github_token.Substring(0,7)


### PR DESCRIPTION
### RSP-398

- adding git action trigger release
- remove the use of PAT when using github rest api

the tag will be "Release_[branch name]_[commit hash]"
I haven't test the script though, script require to merge into default branch first before use ,
I have changed the default branch to `RS2.0-UE5.7`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a triggerable automated release-tagging workflow that creates and pushes annotated release tags and an accompanying commit, and appends a release report to the run summary.
  * Switched release authentication to use a GitHub App token generator for creating releases, removing exposure of personal access tokens.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/disguise-one/RenderStream-UE/pull/135)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->