### PR TITLE
Support Array Parameter Type

### DIFF
--- a/Source/RenderStream/Private/RenderStreamChannelCacheAsset.cpp
+++ b/Source/RenderStream/Private/RenderStreamChannelCacheAsset.cpp
@@ -18,6 +18,8 @@ RenderStreamLink::RemoteParameterType RenderStreamParameterTypeToLink(RenderStre
         return RenderStreamLink::RS_PARAMETER_EVENT;
     case RenderStreamParameterType::Skeleton:
         return RenderStreamLink::RS_PARAMETER_SKELETON;
+    case RenderStreamParameterType::Array:
+        return RenderStreamLink::RS_PARAMETER_ARRAY;
     default:
         check(false);
         return RenderStreamLink::RS_PARAMETER_NUMBER;

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -38,6 +38,7 @@ namespace {
         "Text",
         "Event",
         "Skeleton",
+        "Array",
     };
 
     static_assert(RS_PARAMETER_LAST + 1 == UE_ARRAY_COUNT(ParamTypeName), "Added a new parameter type without adding it's name!");

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -480,6 +480,34 @@ size_t RenderStreamSceneSelector::ValidateParameters(const AActor* Root, RenderS
             validateField(Name, "", RenderStreamLink::RS_PARAMETER_TEXT, parameters[nParameters]);
             ++nParameters;
         }
+        else if (const FArrayProperty* ArrayProperty = CastField<const FArrayProperty>(Property))
+        {
+            // Blueprint floats are stored as FDoubleProperty
+            if (CastField<const FDoubleProperty>(ArrayProperty->Inner))
+            {
+                UE_LOG(LogRenderStream, Log, TEXT("Exposed float array property: %s"), *Name);
+                if (numParameters < nParameters + 1)
+                {
+                    UE_LOG(LogRenderStream, Error, TEXT("Property %s not exposed in schema"), *Name);
+                    return SIZE_MAX;
+                }
+                if (!validateField(Name, "", RenderStreamLink::RS_PARAMETER_ARRAY, parameters[nParameters]))
+                    return SIZE_MAX;
+                FScriptArrayHelper ArrayHelper(ArrayProperty, ArrayProperty->ContainerPtrToValuePtr<void>(Root));
+                if (parameters[nParameters].nElements != uint32_t(ArrayHelper.Num()))
+                {
+                    UE_LOG(LogRenderStream, Error,
+                        TEXT("Float array parameter %s size mismatch: schema has %u elements but actor has %d. Re-save the level."),
+                        *Name, parameters[nParameters].nElements, ArrayHelper.Num());
+                    return SIZE_MAX;
+                }
+                ++nParameters;
+            }
+            else
+            {
+                UE_LOG(LogRenderStream, Warning, TEXT("Unsupported array inner type for property: %s"), *Name);
+            }
+        }
         else
         {
             UE_LOG(LogRenderStream, Warning, TEXT("Unsupported exposed property: %s"), *Name);
@@ -523,6 +551,9 @@ void RenderStreamSceneSelector::ApplyParameters(uint32_t sceneId, const TArray<A
             break;
         case RenderStreamLink::RS_PARAMETER_SKELETON:
             nPoseParams++;
+            break;
+        case RenderStreamLink::RS_PARAMETER_ARRAY:
+            nFloatParams += param.nElements;
             break;
         default:
             UE_LOG(LogRenderStream, Error, TEXT("Unhandled parameter type"));
@@ -882,6 +913,28 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                 TextProperty->SetPropertyValue_InContainer(Root, FText::FromString(UTF8_TO_TCHAR(cString)));
             }
             ++textValues;
+        }
+        else if (const FArrayProperty* ArrayProperty = CastField<const FArrayProperty>(Property))
+        {
+            if (CastField<const FDoubleProperty>(ArrayProperty->Inner))
+            {
+                const RenderStreamLink::RemoteParameter& param = (*ppParams)[iParam];
+                const uint32_t nElements = param.nElements;
+                if (iFloat + nElements > floatValues.size())
+                {
+                    UE_LOG(LogRenderStream, Verbose, TEXT("Attempt to read float array value from disguise that is out of range. Does the metadata need to be regenerated?"));
+                }
+                else
+                {
+                    FScriptArrayHelper ArrayHelper(ArrayProperty, ArrayProperty->ContainerPtrToValuePtr<void>(Root));
+                    ArrayHelper.Resize(nElements);
+                    for (uint32_t i = 0; i < nElements; ++i)
+                    {
+                        *reinterpret_cast<double*>(ArrayHelper.GetRawPtr(i)) = double(floatValues[iFloat + i]);
+                    }
+                    iFloat += nElements;
+                }
+            }
         }
         ++iParam;
     }

--- a/Source/RenderStream/Public/RenderStreamChannelCacheAsset.h
+++ b/Source/RenderStream/Public/RenderStreamChannelCacheAsset.h
@@ -19,6 +19,7 @@ enum class RenderStreamParameterType : uint8
     Text,
     Event,
     Skeleton,
+    Array,
 };
 
 RENDERSTREAM_API RenderStreamLink::RemoteParameterType RenderStreamParameterTypeToLink(RenderStreamParameterType type);
@@ -47,6 +48,8 @@ public:
     FString DefaultValue;
     UPROPERTY(EditAnywhere, Category = "ExposedParameter")
     TArray<FString> Options;
+    UPROPERTY(EditAnywhere, Category = "ExposedParameter")
+    uint32 NumElements = 0;
     UPROPERTY(EditAnywhere, Category = "ExposedParameter")
     int32 DmxOffset;
     UPROPERTY(EditAnywhere, Category = "ExposedParameter")

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -252,7 +252,8 @@ public:
         RS_PARAMETER_TEXT,
         RS_PARAMETER_EVENT,
         RS_PARAMETER_SKELETON,
-        RS_PARAMETER_LAST= RS_PARAMETER_SKELETON
+        RS_PARAMETER_ARRAY,
+        RS_PARAMETER_LAST= RS_PARAMETER_ARRAY
     };
     static const char* ParamTypeToName(RemoteParameterType type);
 
@@ -316,6 +317,7 @@ public:
         int32_t dmxOffset; // DMX channel offset or auto (-1)
         RemoteParameterDmxType dmxType;
         uint32_t flags; // REMOTEPARAMETER_FLAGS
+        uint32_t nElements;
     } RemoteParameter;
 
     typedef struct

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -198,7 +198,15 @@ void CreateField(FRenderStreamExposedParameterEntry& parameter, FString group, F
 {
     check(type != RenderStreamParameterType::Float);
     check(type != RenderStreamParameterType::Text);
+    check(type != RenderStreamParameterType::Array);
     CreateFieldInternal(parameter, group, displayName_, suffix, key_, undecoratedSuffix, type, 0, 0, 0, "");
+}
+
+void CreateField(FRenderStreamExposedParameterEntry& parameter, FString group, FString displayName_, FString suffix, FString key_, FString undecoratedSuffix, RenderStreamParameterType type, float min, float max, float step, float defaultValue, uint32 nElements)
+{
+    check(type == RenderStreamParameterType::Array);
+    CreateFieldInternal(parameter, group, displayName_, suffix, key_, undecoratedSuffix, type, min, max, step, FString::SanitizeFloat(defaultValue));
+    parameter.NumElements = nElements;
 }
 
 
@@ -423,9 +431,7 @@ void GenerateParameters(TArray<FRenderStreamExposedParameterEntry>& Parameters, 
                     const bool HasLimits = Property->HasMetaData("ClampMin") && Property->HasMetaData("ClampMax");
                     const float Min = HasLimits ? FCString::Atof(*Property->GetMetaData("ClampMin")) : -1;
                     const float Max = HasLimits ? FCString::Atof(*Property->GetMetaData("ClampMax")) : +1;
-                    FRenderStreamExposedParameterEntry& Entry = Parameters.Emplace_GetRef();
-                    CreateFieldInternal(Entry, Category, Name, "", Name, "", RenderStreamParameterType::Array, Min, Max, 0.001f, "0");
-                    Entry.NumElements = nElements;
+                    CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Array, Min, Max, 0.001f, 0.f, nElements);
                 }
             }
             else

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -212,7 +212,7 @@ static void ConvertFields(RenderStreamLink::RemoteParameter* outputIterator, con
         parameter.displayName = _strdup(TCHAR_TO_UTF8(*entry.DisplayName));
         parameter.key = _strdup(TCHAR_TO_UTF8(*entry.Key));
         parameter.type = RenderStreamParameterTypeToLink(entry.Type);
-        if (parameter.type == RenderStreamLink::RS_PARAMETER_NUMBER)
+        if (parameter.type == RenderStreamLink::RS_PARAMETER_NUMBER || parameter.type == RenderStreamLink::RS_PARAMETER_ARRAY)
         {
             parameter.defaults.number.min = entry.Min;
             parameter.defaults.number.max = entry.Max;
@@ -232,6 +232,7 @@ static void ConvertFields(RenderStreamLink::RemoteParameter* outputIterator, con
         parameter.dmxOffset = -1; // Auto
         parameter.dmxType = RenderStreamLink::RS_DMX_16_BE;
         parameter.flags = RenderStreamLink::REMOTEPARAMETER_NO_FLAGS;
+        parameter.nElements = entry.NumElements;
     }
 }
 
@@ -405,6 +406,32 @@ void GenerateParameters(TArray<FRenderStreamExposedParameterEntry>& Parameters, 
             const FString s = v.ToString();
             UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed text property: %s is %s"), *Name, *s);
             CreateField(Parameters.Emplace_GetRef(), Category, Name, "", Name, "", RenderStreamParameterType::Text, s);
+        }
+        else if (const FArrayProperty* ArrayProperty = CastField<const FArrayProperty>(Property))
+        {
+            if (CastField<const FDoubleProperty>(ArrayProperty->Inner))
+            {
+                FScriptArrayHelper ArrayHelper(ArrayProperty, ArrayProperty->ContainerPtrToValuePtr<void>(Root));
+                const uint32 nElements = ArrayHelper.Num();
+                if (nElements == 0)
+                {
+                    UE_LOG(LogRenderStreamEditor, Warning, TEXT("Skipping float array property %s: array is empty - size the array in the editor before exposing it"), *Name);
+                }
+                else
+                {
+                    UE_LOG(LogRenderStreamEditor, Log, TEXT("Exposed float array property: %s with %u elements"), *Name, nElements);
+                    const bool HasLimits = Property->HasMetaData("ClampMin") && Property->HasMetaData("ClampMax");
+                    const float Min = HasLimits ? FCString::Atof(*Property->GetMetaData("ClampMin")) : -1;
+                    const float Max = HasLimits ? FCString::Atof(*Property->GetMetaData("ClampMax")) : +1;
+                    FRenderStreamExposedParameterEntry& Entry = Parameters.Emplace_GetRef();
+                    CreateFieldInternal(Entry, Category, Name, "", Name, "", RenderStreamParameterType::Array, Min, Max, 0.001f, "0");
+                    Entry.NumElements = nElements;
+                }
+            }
+            else
+            {
+                UE_LOG(LogRenderStreamEditor, Warning, TEXT("Unsupported array inner type for property: %s"), *Name);
+            }
         }
         else
         {


### PR DESCRIPTION
[RSP-385](https://d3technologies.atlassian.net/browse/RSP-385?atlOrigin=eyJpIjoiMzI1MDVkNTBkNzM4NDRhNzkwOThhZTk0MmVhNzQ0MjciLCJwIjoiaiJ9)

### Summary

D3 already supports array parameters when using notch. This change allows float array parameters created in the blueprint to be exposed to d3. Since arrays need to be handled differently a new type is used instead of try to represent it as a number. It essentially follows the same pattern as the other types.


[RSP-385]: https://d3technologies.atlassian.net/browse/RSP-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ