### PR TITLE
Restores automatic regeneration of the schema on save

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -49,6 +49,10 @@
 #include "DesktopPlatformModule.h"
 #include "IDesktopPlatform.h"
 
+#include "LevelEditor.h"
+#include "LevelEditorActions.h"
+#include "Framework/Commands/UICommandList.h"
+
 DEFINE_LOG_CATEGORY(LogRenderStreamEditor);
 
 #define LOCTEXT_NAMESPACE "RenderStreamEditor"
@@ -85,10 +89,11 @@ void FRenderStreamEditorModule::StartupModule()
 
         UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(
             this, &FRenderStreamEditorModule::RegisterToolBarButton));
+
+        UToolMenus::RegisterStartupCallback(FSimpleMulticastDelegate::FDelegate::CreateRaw(
+            this, &FRenderStreamEditorModule::RegisterSaveCommandOverrides));
     }
 
-    FEditorDelegates::PostSaveExternalActors.AddRaw(this, &FRenderStreamEditorModule::OnPostSaveWorld);
-    FEditorDelegates::PostSaveWorldWithContext.AddRaw(this, &FRenderStreamEditorModule::OnPostSaveWorldContext);
     FEditorDelegates::OnAssetsDeleted.AddRaw(this, &FRenderStreamEditorModule::OnAssetsDeleted);
     FCoreDelegates::OnBeginFrame.AddRaw(this, &FRenderStreamEditorModule::OnBeginFrame);
     FCoreDelegates::OnPostEngineInit.AddRaw(this, &FRenderStreamEditorModule::OnPostEngineInit);
@@ -113,8 +118,6 @@ void FRenderStreamEditorModule::ShutdownModule()
         PropertyModule.UnregisterCustomClassLayout("RenderStreamSettings");
     }
 
-    FEditorDelegates::PostSaveExternalActors.RemoveAll(this);
-    FEditorDelegates::PostSaveWorldWithContext.RemoveAll(this);
     FEditorDelegates::OnAssetsDeleted.RemoveAll(this);
     FCoreDelegates::OnBeginFrame.RemoveAll(this);
     FCoreDelegates::OnPostEngineInit.RemoveAll(this);
@@ -1002,15 +1005,40 @@ void FRenderStreamEditorModule::RegisterToolBarButton()
     ));
 }
 
-void FRenderStreamEditorModule::OnPostSaveWorldContext(UWorld* World, FObjectPostSaveContext context)
+void FRenderStreamEditorModule::RegisterSaveCommandOverrides()
 {
-    if (context.SaveSucceeded())
-        DirtyAssetMetadata = true;
-}
+    FLevelEditorModule* LevelEditorModule = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor");
+    if (!LevelEditorModule)
+        return;
 
-void FRenderStreamEditorModule::OnPostSaveWorld(UWorld* World)
-{
-    DirtyAssetMetadata = true;
+    const TSharedRef<FUICommandList> CommandList = LevelEditorModule->GetGlobalLevelEditorActions();
+
+    auto WrapSaveCommand = [this, &CommandList](const TSharedPtr<FUICommandInfo>& Command)
+    {
+        if (!Command.IsValid())
+            return;
+
+        const FUIAction* ExistingAction = CommandList->GetActionForCommand(Command);
+        if (!ExistingAction)
+            return;
+
+        // Copy the existing action so we preserve CanExecute/visibility, then chain schema regeneration
+        FUIAction WrappedAction = *ExistingAction;
+        const FExecuteAction OriginalExecute = WrappedAction.ExecuteAction;
+        WrappedAction.ExecuteAction = FExecuteAction::CreateLambda([this, OriginalExecute]()
+        {
+            if (OriginalExecute.IsBound())
+                OriginalExecute.Execute();
+
+            // Mark dirty so OnBeginFrame regenerates next tick, regardless of whether a package was written.
+            DirtyAssetMetadata = true;
+        });
+
+        CommandList->MapAction(Command, WrappedAction);
+    };
+
+    WrapSaveCommand(FLevelEditorCommands::Get().Save);
+    WrapSaveCommand(FLevelEditorCommands::Get().SaveAllLevels);
 }
 
 void FRenderStreamEditorModule::OnAssetsDeleted(const TArray<UClass*>& DeletedAssetClasses)

--- a/Source/RenderStreamEditor/Public/RenderStreamEditorModule.h
+++ b/Source/RenderStreamEditor/Public/RenderStreamEditorModule.h
@@ -20,6 +20,7 @@ public:
 
     void RunPackageAndCopy();
     void RegisterToolBarButton();
+    void RegisterSaveCommandOverrides();
 
 private:
     FString StreamName();
@@ -28,8 +29,6 @@ private:
 
     // Delegates
     void OnBeginFrame();
-    void OnPostSaveWorldContext(UWorld* World, FObjectPostSaveContext context);
-    void OnPostSaveWorld(UWorld* World);
     void OnAssetsDeleted(const TArray<UClass*>& DeletedAssetClasses);
 
     void OnPostEngineInit();


### PR DESCRIPTION
[RSP-397](https://d3technologies.atlassian.net/browse/RSP-397)

**Description:**
The editor module regenerated the schema by listening to `FEditorDelegates::PostSaveExternalActors()` and
`PostSaveWorldWithContext()`. After upgrading to UE 5.6 these delegates no longer fire reliably on a plain save, since UE5.6 only write packages that are actually dirty. As a result, the schema went stale until the user happened to modify an object in the scene. 

**Solution:**
 Intercept the Save command instead of listening for a save: `RegisterSaveCommandOverrides()` wraps the level editor's
 `Save `and `SaveAllLevels` actions in the global command list, so it preserves the original CanExecute/visibility, runs the
 original save, then sets `DirtyAssetMetadata = true` regardless of whether any package was written.

In addition, I removed the stale delegates.

[RSP-397]: https://d3technologies.atlassian.net/browse/RSP-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ