### PR TITLE
Error message in schema generation when using old incompatible d3 version

### DIFF
--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -19,6 +19,7 @@
 THIRD_PARTY_INCLUDES_START
 #include <winver.h>
 THIRD_PARTY_INCLUDES_END
+#include "Windows/HideWindowsPlatformTypes.h"
 #pragma comment(lib, "version.lib")
 #endif
 
@@ -287,18 +288,7 @@ bool RenderStreamLink::IsSchemaGenerationSupported() const
         return false;
     }
 
-    const bool supported =
-        (major > MIN_D3_VERSION_MAJOR) ||
+    return (major > MIN_D3_VERSION_MAJOR) ||
         (major == MIN_D3_VERSION_MAJOR && minor > MIN_D3_VERSION_MINOR) ||
         (major == MIN_D3_VERSION_MAJOR && minor == MIN_D3_VERSION_MINOR && patch >= MIN_D3_VERSION_PATCH);
-
-    if (!supported)
-    {
-        UE_LOG(LogRenderStream, Error,
-            TEXT("Installed d3 version %d.%d.%d is too old for RenderStream schema generation; d3 version r%d.%d.%d or newer is required."),
-            major, minor, patch,
-            MIN_D3_VERSION_MAJOR, MIN_D3_VERSION_MINOR, MIN_D3_VERSION_PATCH);
-    }
-
-    return supported;
 }

--- a/Source/RenderStream/Private/RenderStreamLink.cpp
+++ b/Source/RenderStream/Private/RenderStreamLink.cpp
@@ -14,6 +14,14 @@
 #include "Interfaces/IPluginManager.h"
 #include "Windows/MinWindows.h"
 
+#ifdef WINDOWS
+#include "Windows/AllowWindowsPlatformTypes.h"
+THIRD_PARTY_INCLUDES_START
+#include <winver.h>
+THIRD_PARTY_INCLUDES_END
+#pragma comment(lib, "version.lib")
+#endif
+
 namespace {
     void log_default(const char* text) {
         UE_LOG(LogRenderStream, Log, TEXT("%s"), ANSI_TO_TCHAR(text));
@@ -125,8 +133,8 @@ bool RenderStreamLink::loadExplicit()
 
     const FString dllName("d3renderstream.dll");
     const FString exePath = GetD3PathFromReg();
-    const FString dllPath = exePath + dllName;
-    if (!FPaths::FileExists(dllPath))
+    m_dllPath = exePath + dllName;
+    if (!FPaths::FileExists(m_dllPath))
     {
         UE_LOG(LogRenderStream, Error, TEXT("%s not found in %s."), *dllName, *exePath);
         return false;
@@ -138,13 +146,13 @@ bool RenderStreamLink::loadExplicit()
             UE_LOG(LogRenderStream, Fatal, TEXT("RenderStream instance cannot launch, the app will exit to avoid other RenderStram errors during runtime. Reason: %s"), *msg);
     };
 
-    UE_LOG(LogRenderStream, Log, TEXT("Loading RenderStream dll at %s."), *dllPath);
-    m_dll = LoadLibraryEx(*dllPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS);
+    UE_LOG(LogRenderStream, Log, TEXT("Loading RenderStream dll at %s."), *m_dllPath);
+    m_dll = LoadLibraryEx(*m_dllPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS);
     if (m_dll == nullptr)
     {
         std::error_code e = std::error_code(GetLastError(), std::system_category());
         FString osMsg = e.message().c_str();
-        UE_LOG(LogRenderStream, Error, TEXT("Failed to load %s. %s (%i)"), *dllPath, *osMsg, e.value());
+        UE_LOG(LogRenderStream, Error, TEXT("Failed to load %s. %s (%i)"), *m_dllPath, *osMsg, e.value());
         LogFatalIfNotInEditor("RenderStream DLL could not be loaded.");
         return false;
     }
@@ -238,4 +246,59 @@ bool RenderStreamLink::unloadExplicit()
 #endif
     m_loaded = false;
     return m_dll == nullptr;
+}
+
+bool RenderStreamLink::GetD3Version(int32& OutMajor, int32& OutMinor, int32& OutPatch) const
+{
+#ifdef WINDOWS
+    if (m_dllPath.IsEmpty())
+        return false;
+
+    DWORD ignored = 0;
+    const DWORD infoSize = GetFileVersionInfoSizeW(*m_dllPath, &ignored);
+    if (infoSize == 0)
+        return false;
+
+    TArray<uint8> buffer;
+    buffer.SetNumUninitialized(static_cast<int32>(infoSize));
+    if (!GetFileVersionInfoW(*m_dllPath, 0, infoSize, buffer.GetData()))
+        return false;
+
+    VS_FIXEDFILEINFO* fixedInfo = nullptr;
+    UINT fixedInfoLen = 0;
+    if (!VerQueryValueW(buffer.GetData(), L"\\", reinterpret_cast<LPVOID*>(&fixedInfo), &fixedInfoLen) || fixedInfo == nullptr)
+        return false;
+
+    OutMajor = static_cast<int32>(HIWORD(fixedInfo->dwFileVersionMS));
+    OutMinor = static_cast<int32>(LOWORD(fixedInfo->dwFileVersionMS));
+    OutPatch = static_cast<int32>(HIWORD(fixedInfo->dwFileVersionLS));
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool RenderStreamLink::IsSchemaGenerationSupported() const
+{
+    int32 major = 0, minor = 0, patch = 0;
+    if (!GetD3Version(major, minor, patch))
+    {
+        UE_LOG(LogRenderStream, Error, TEXT("Could not determine installed d3 version; treating schema generation as unsupported."));
+        return false;
+    }
+
+    const bool supported =
+        (major > MIN_D3_VERSION_MAJOR) ||
+        (major == MIN_D3_VERSION_MAJOR && minor > MIN_D3_VERSION_MINOR) ||
+        (major == MIN_D3_VERSION_MAJOR && minor == MIN_D3_VERSION_MINOR && patch >= MIN_D3_VERSION_PATCH);
+
+    if (!supported)
+    {
+        UE_LOG(LogRenderStream, Error,
+            TEXT("Installed d3 version %d.%d.%d is too old for RenderStream schema generation; d3 version r%d.%d.%d or newer is required."),
+            major, minor, patch,
+            MIN_D3_VERSION_MAJOR, MIN_D3_VERSION_MINOR, MIN_D3_VERSION_PATCH);
+    }
+
+    return supported;
 }

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -362,6 +362,10 @@ public:
 #define RENDER_STREAM_VERSION_MAJOR 3
 #define RENDER_STREAM_VERSION_MINOR 0
 
+#define MIN_D3_VERSION_MAJOR 33
+#define MIN_D3_VERSION_MINOR 2
+#define MIN_D3_VERSION_PATCH 0
+
     enum UseDX12SharedHeapFlag
     {
         RS_DX12_USE_SHARED_HEAP_FLAG,
@@ -471,6 +475,9 @@ public:
 
     bool loadExplicit();
     bool unloadExplicit();
+
+    bool GetD3Version(int32& OutMajor, int32& OutMinor, int32& OutPatch) const;
+    RENDERSTREAM_API bool IsSchemaGenerationSupported() const;
 
     struct ScopedSchema
     {
@@ -597,6 +604,7 @@ public: // d3renderstream.h API, but loaded dynamically.
 private:
     bool m_loaded = false;
     void* m_dll = nullptr;
+    FString m_dllPath;
 };
 
 //template<typename Fn>

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -363,7 +363,7 @@ public:
 #define RENDER_STREAM_VERSION_MINOR 0
 
 #define MIN_D3_VERSION_MAJOR 33
-#define MIN_D3_VERSION_MINOR 2
+#define MIN_D3_VERSION_MINOR 3
 #define MIN_D3_VERSION_PATCH 0
 
     enum UseDX12SharedHeapFlag

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -774,6 +774,17 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
         return;
     }
 
+    if (!RenderStreamLink::instance().IsSchemaGenerationSupported())
+    {
+        const FString msg = FString::Printf(
+            TEXT("Cannot generate RenderStream schema: the installed d3 version is unsupported or could not be determined. Schema generation requires d3 r%d.%d.%d or newer."),
+            MIN_D3_VERSION_MAJOR, MIN_D3_VERSION_MINOR, MIN_D3_VERSION_PATCH);
+        UE_LOG(LogRenderStreamEditor, Error, TEXT("%s"), *msg);
+        if (GEngine)
+            GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Red, msg);
+        return;
+    }
+
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
 
     // Update currently loaded levels

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -768,12 +768,7 @@ void FRenderStreamEditorModule::RunValidation(const TArray<URenderStreamChannelC
 
 void FRenderStreamEditorModule::GenerateAssetMetadata()
 {
-    if (!RenderStreamLink::instance().isAvailable())
-    {
-        UE_LOG(LogRenderStreamEditor, Warning, TEXT("RenderStreamLink unavailable, skipped GenerateAssetMetadata"));
-        return;
-    }
-
+    // Check the installed d3 version first.
     if (!RenderStreamLink::instance().IsSchemaGenerationSupported())
     {
         const FString msg = FString::Printf(
@@ -782,6 +777,12 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
         UE_LOG(LogRenderStreamEditor, Error, TEXT("%s"), *msg);
         if (GEngine)
             GEngine->AddOnScreenDebugMessage(-1, 20.f, FColor::Red, msg);
+        return;
+    }
+
+    if (!RenderStreamLink::instance().isAvailable())
+    {
+        UE_LOG(LogRenderStreamEditor, Warning, TEXT("RenderStreamLink unavailable, skipped GenerateAssetMetadata"));
         return;
     }
 


### PR DESCRIPTION
[RSP-401](https://d3technologies.atlassian.net/browse/RSP-401)

**Description:**
Old d3 version and plugin RS3.0-UE5.x are not backward compatible. This caused the schema generation to fail, causing an accesses violation that would be only seen in Output Logs of UE editor (which can be missed easily.)

Solution was to gate schema generation, so before calling `rs_saveSchema`, we read the actual `d3renderstream.dll` file version and refuse generation with a clear actionable message, which also points to the first supported d3 version. The error looks like this in the UE editor:
<img width="1306" height="853" alt="image" src="https://github.com/user-attachments/assets/9f388e2c-d7fc-499a-b8a6-05833b6e08aa" />


[RSP-401]: https://d3technologies.atlassian.net/browse/RSP-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ