### PR TITLE
RSP-403 fix startup crash

### DIFF
--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -98,6 +98,14 @@ namespace RSUCHelpers
         FVector2f CropV)
     {
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Send Frame"));
+
+        // Skip frame instead of crashing when the texture is not ready
+        if (!BufTexture.IsValid())
+        {
+            UE_LOG(LogRenderStream, Verbose, TEXT("RS SendFrame: stream buffer not ready yet; skipping frame."));
+            return;
+        }
+
         // convert the source with a draw call
         FGraphicsPipelineStateInitializer GraphicsPSOInit;
         FRHITexture* RenderTarget = BufTexture.GetReference();


### PR DESCRIPTION
Compressed + Packaged build expose a timing issue. Each stream has a buffer texture which is created asynchronously on the render queue. With tighter timings, it's possible to attempt using this texture before it's initialized.

Solution: add safety by dropping the frame in SendFrame when texture note ready.

This bug was discovered when testing packaged builds in RSP-403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when sending rendered frames by skipping processing if the destination texture is not available.
  * Added a safe early exit and logging to help avoid crashes in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->