### PR TITLE
RSP-403 Fix project packaging

### DIFF
--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -97,6 +97,14 @@ namespace RSUCHelpers
         FVector2f CropV)
     {
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Send Frame"));
+
+        // Skip frame instead of crashing when the texture is not ready
+        if (!BufTexture.IsValid())
+        {
+            UE_LOG(LogRenderStream, Verbose, TEXT("RS SendFrame: stream buffer not ready yet; skipping frame."));
+            return;
+        }
+
         // convert the source with a draw call
         FGraphicsPipelineStateInitializer GraphicsPSOInit;
         FRHITexture* RenderTarget = BufTexture.GetReference();

--- a/Source/RenderStream/Private/RSUCHelpers.inl
+++ b/Source/RenderStream/Private/RSUCHelpers.inl
@@ -98,6 +98,14 @@ namespace RSUCHelpers
         FVector2f CropV)
     {
         SCOPED_DRAW_EVENTF(RHICmdList, MediaCapture, TEXT("RS Send Frame"));
+
+        // Skip frame instead of crashing when the texture is not ready
+        if (!BufTexture.IsValid())
+        {
+            UE_LOG(LogRenderStream, Verbose, TEXT("RS SendFrame: stream buffer not ready yet; skipping frame."));
+            return;
+        }
+
         // convert the source with a draw call
         FGraphicsPipelineStateInitializer GraphicsPSOInit;
         FRHITexture* RenderTarget = BufTexture.GetReference();

--- a/Source/RenderStream/Private/RenderStreamViewportClient.cpp
+++ b/Source/RenderStream/Private/RenderStreamViewportClient.cpp
@@ -69,51 +69,51 @@
 
 // Debug feature to synchronize and force all external resources to be transferred cross GPU at the end of graph execution.
 // May be useful for testing cross GPU synchronization logic.
-int32 GDisplayClusterForceCopyCrossGPU = 0;
-static FAutoConsoleVariableRef CVarDisplayClusterForceCopyCrossGPU(
-    TEXT("DC.ForceCopyCrossGPU"),
-    GDisplayClusterForceCopyCrossGPU,
+int32 GRenderStreamForceCopyCrossGPU = 0;
+static FAutoConsoleVariableRef CVarRenderStreamForceCopyCrossGPU(
+    TEXT("RS.ForceCopyCrossGPU"),
+    GRenderStreamForceCopyCrossGPU,
     TEXT("Force cross GPU copy of all resources after each view render.  Bad for perf, but may be useful for debugging."),
     ECVF_RenderThreadSafe
 );
 
-int32 GDisplayClusterShowStats = 0;
-static FAutoConsoleVariableRef CVarDisplayClusterShowStats(
-    TEXT("DC.Stats"),
-    GDisplayClusterShowStats,
+int32 GRenderStreamShowStats = 0;
+static FAutoConsoleVariableRef CVarRenderStreamShowStats(
+    TEXT("RS.Stats"),
+    GRenderStreamShowStats,
     TEXT("Show per-view profiling stats for display cluster rendering."),
     ECVF_RenderThreadSafe
 );
 
-int32 GDisplayClusterSingleRender = 1;
-static FAutoConsoleVariableRef CVarDisplayClusterSingleRender(
-    TEXT("DC.SingleRender"),
-    GDisplayClusterSingleRender,
+int32 GRenderStreamSingleRender = 1;
+static FAutoConsoleVariableRef CVarRenderStreamSingleRender(
+    TEXT("RS.SingleRender"),
+    GRenderStreamSingleRender,
     TEXT("Render Display Cluster view families in a single scene render."),
     ECVF_RenderThreadSafe
 );
 
-int32 GDisplayClusterSortViews = 1;
-static FAutoConsoleVariableRef CVarDisplayClusterSortViews(
-    TEXT("DC.SortViews"),
-    GDisplayClusterSortViews,
+int32 GRenderStreamSortViews = 1;
+static FAutoConsoleVariableRef CVarRenderStreamSortViews(
+    TEXT("RS.SortViews"),
+    GRenderStreamSortViews,
     TEXT("Enable sorting of views by decreasing pixel count and decreasing GPU index.  Adds determinism, and tends to run inners first, which helps with scheduling, improving perf (default: enabled)."),
     ECVF_RenderThreadSafe
 );
 
-int32 GDisplayClusterDebugDraw = 1;
-static FAutoConsoleVariableRef CVarDisplayClusterDebugDraw(
-    TEXT("DC.DebugDraw"),
-    GDisplayClusterDebugDraw,
+int32 GRenderStreamDebugDraw = 1;
+static FAutoConsoleVariableRef CVarRenderStreamDebugDraw(
+    TEXT("RS.DebugDraw"),
+    GRenderStreamDebugDraw,
     TEXT("Enable debug draw for nDisplay views.  Debug draw features are separately enabled, and default to off, this just provides an additional global toggle."),
     ECVF_RenderThreadSafe
 );
 
 // Replaces FApp::HasFocus
-bool GDisplayClusterReplaceHasFocusFunction = true;
-static FAutoConsoleVariableRef CVarDisplayClusterReplaceHasFocusFunction(
-    TEXT("DC.ReplaceHasFocusFunction"),
-    GDisplayClusterReplaceHasFocusFunction,
+bool GRenderStreamReplaceHasFocusFunction = true;
+static FAutoConsoleVariableRef CVarRenderStreamReplaceHasFocusFunction(
+    TEXT("RS.ReplaceHasFocusFunction"),
+    GRenderStreamReplaceHasFocusFunction,
     TEXT("Replaces the function that FApp::HasFocus() uses, to mitigate OS stalls that happen in some systems."),
     ECVF_ReadOnly
 );
@@ -193,7 +193,7 @@ void URenderStreamViewportClient::Init(struct FWorldContext& WorldContext, UGame
 
         // Replace FApp::HasFocus to avoid stalls observed in some render nodes. 
         // It always return true, so all code behaves as if the application were in focus, even when rendering offscreen.
-        if (GDisplayClusterReplaceHasFocusFunction)
+        if (GRenderStreamReplaceHasFocusFunction)
         {
             FApp::SetHasFocusFunction([]() { return true; });
         }
@@ -429,14 +429,6 @@ private:
 
 void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanvas)
 {
-    /// !!!! disguise customizations
-    static const auto DisplayClusterForceCopyCrossGPU = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.ForceCopyCrossGPU"));
-    static const auto DisplayClusterLumenPerView = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.LumenPerView"));
-    static const auto DisplayClusterSortViews = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SortViews"));
-    static const auto DisplayClusterSingleRender = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.SingleRender"));
-    static const auto DisplayClusterDebugDraw = IConsoleManager::Get().FindConsoleVariable(TEXT("DC.DebugDraw"));
-    /// !!!! disguise customizations
-
     ////////////////////////////////
     // For any operation mode other than 'Cluster' we use default UGameViewportClient::Draw pipeline
     /// !!!! disguise customizations - we must always use this method.
@@ -798,7 +790,7 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
                 ViewFamily.bIsHDR = GetWindow().IsValid() ? GetWindow().Get()->GetIsHDR() : false;
 
 #if WITH_MGPU
-                ViewFamily.bForceCopyCrossGPU = GDisplayClusterForceCopyCrossGPU != 0;
+                ViewFamily.bForceCopyCrossGPU = GRenderStreamForceCopyCrossGPU != 0;
 #endif
 
                 ViewFamily.ProfileDescription = DCViewFamily.Views[0].Viewport->GetId();
@@ -828,7 +820,7 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
         if (ViewFamilies.Num() > 1)
         {
 #if WITH_MGPU
-            if (GDisplayClusterSortViews)
+            if (GRenderStreamSortViews)
             {
                 ViewFamilies.StableSort(FCompareViewFamilyBySizeAndGPU());
             }
@@ -846,7 +838,7 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
             }
         }
 
-        if (GDisplayClusterSingleRender)
+        if (GRenderStreamSingleRender)
         {
             GetRendererModule().BeginRenderingViewFamilies(
                 SceneCanvas, MakeArrayView(reinterpret_cast<FSceneViewFamily* const*>(ViewFamilies.GetData()), ViewFamilies.Num()));
@@ -932,7 +924,7 @@ void URenderStreamViewportClient::Draw(FViewport* InViewport, FCanvas* SceneCanv
 #endif
         }
 
-        if (GDisplayClusterDebugDraw && !ViewFamilies.IsEmpty())
+        if (GRenderStreamDebugDraw && !ViewFamilies.IsEmpty())
         {
             UDebugDrawService::Draw(ViewFamilies.Last()->EngineShowFlags, InViewport, const_cast<FSceneView*>(ViewFamilies.Last()->Views[0]), DebugCanvas, DebugCanvasObject);
         }

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -28,7 +28,7 @@ typedef uint64_t VkDeviceSize;
 typedef struct VkSemaphore_T* VkSemaphore;
 
 #define RS_PLUGIN_NAME "RenderStream-UE"
-#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v4"
+#define RS_PLUGIN_VERSION "RS2.0-UE5.5-v5"
 
 class RenderStreamLink
 {


### PR DESCRIPTION
# RSP-403

## Summary

Packaging projects in UE5.6 failed with linker errors due to duplicated global variables between DisplayCluster and RenderStreamViewportClient. 

Solution: Rename the RenderStream copies of the variables. This operation is safe, since the globals are only used locally within the file.

## Additional notes:

Two additional changes are included in this PR:
The fix for startup crash from https://github.com/disguise-one/RenderStream-UE/pull/145
Some dead code cleanup in `URenderStreamViewportClient::Draw`