### PR TITLE
OCIO Texture Parameters Broken With Compressed Streams

### DIFF
--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -872,7 +872,9 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     if (!textureColourTransform->bGPUSharedFlag || textureColourTransform->GetFormat() != formatMap[frameData.format].ue)
                     {
                         textureColourTransform->bGPUSharedFlag = true;
-                        textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, false);
+                        // Force linear as per the RST-353 comment
+                        textureColourTransform->SRGB = 0;
+                        textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, true);
                     }
                     else if (textureColourTransform->SizeX != frameData.width || textureColourTransform->SizeY != frameData.height)
                     {

--- a/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
+++ b/Source/RenderStream/Private/RenderStreamSceneSelector.cpp
@@ -873,7 +873,6 @@ void RenderStreamSceneSelector::ApplyParameters(AActor* Root, uint64_t specHash,
                     {
                         textureColourTransform->bGPUSharedFlag = true;
                         // Force linear as per the RST-353 comment
-                        textureColourTransform->SRGB = 0;
                         textureColourTransform->InitCustomFormat(frameData.width, frameData.height, formatMap[frameData.format].ue, true);
                     }
                     else if (textureColourTransform->SizeX != frameData.width || textureColourTransform->SizeY != frameData.height)


### PR DESCRIPTION
See [RSP-407](https://d3technologies.atlassian.net/browse/RSP-407?atlOrigin=eyJpIjoiMjY5Y2FmNDQ3MTkwNDA3NTk0ODM1NmU1ZTY4ZGE5ZDgiLCJwIjoiaiJ9)

When using OCIO texture parameters with compressed streams the resulting image is extremely dark. This is due to UE forcing a decode of an intermediate texture before it is handed over to OCIO. It seems UE makes an assumption that all integer data must already be encoded as an sRGB texture so it proactively applies a decode to get back the linear pixel data. However when using compressed streams we use integer pixel data but we do not encode it to sRGB by the time UE is making this assumption (probably every time the texture is sampled by OCIO). So before any OCIO transform is applied UE does an unnecessary conversion causing the colours to look very off. The reason that this does not affect RSUC is because we are using float pixel values, UE does not apply the same assumption for floats since the precision is high enough that encoding to sRGB is not needed.

The fix (made by Ivaylo) is to force the data to remain linear by setting the last flag in InitCustomFormat to true. We can also set the SRGB field for the texture to be 0 to be extra clear that the current data is not sRGB encoded. This doesn't affect the already working RSUC streams as they were already being treated as linear.

[RSP-407]: https://d3technologies.atlassian.net/browse/RSP-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ