### PR TITLE
When nDisplay controller is present, wait for the controller to instruct exit

### DIFF
--- a/Source/RenderStream/Private/SyncFrameData.cpp
+++ b/Source/RenderStream/Private/SyncFrameData.cpp
@@ -236,7 +236,17 @@ void FRenderStreamSyncFrameData::Apply() const
 void FRenderStreamSyncFrameData::QuitNow() const
 {
     TRACE_CPUPROFILER_EVENT_SCOPE(TEXT("FRenderStreamSyncFrameData::QuitNow()"));
+
     RenderStreamLink::instance().rs_setNewStatusMessage("");
+
+    IDisplayClusterClusterManager* ClusterMgr = IDisplayCluster::IsAvailable() ? IDisplayCluster::Get().GetClusterMgr() : nullptr;
+
+    if (ClusterMgr && !ClusterMgr->IsPrimary())
+    {
+        UE_LOG(LogRenderStream, Log, TEXT("RenderStream requested quit, waiting for nDisplay primary to terminate this node"));
+        return;
+    }
+
     UE_LOG(LogRenderStream, Log, TEXT("Quitting due to RenderStream request"));
     FPlatformMisc::RequestExit(false);
 }


### PR DESCRIPTION
Makes non-primary ndisplay nodes in the renderstream session exit cleanly.

DSOF-32277