### PR TITLE
Refactor Maps Mode

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -40,6 +40,7 @@
 
 #include "FileHelpers.h"
 #include "GameMapsSettings.h"
+#include "Settings/ProjectPackagingSettings.h"
 
 #include "Logging/MessageLog.h"
 #include "Misc/UObjectToken.h"
@@ -907,11 +908,33 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
             }
         }
 
-        Schema.schema.scenes.nScenes = ChannelCaches.Num();
+        // If the project's packaging settings specify an explicit list of maps to include in the
+        // packaged build, only save those maps to the schema. Otherwise save every map we cached.
+        const UProjectPackagingSettings* PackagingSettings = GetDefault<UProjectPackagingSettings>();
+        const bool bUseExplicitMapList = PackagingSettings && PackagingSettings->MapsToCook.Num() > 0;
+
+        TSet<FString> PackagedMaps;
+        if (bUseExplicitMapList)
+        {
+            for (const FFilePath& Map : PackagingSettings->MapsToCook)
+                PackagedMaps.Add(Map.FilePath);
+        }
+
+        TArray<const URenderStreamChannelCacheAsset*> MapsToSave;
+        for (const URenderStreamChannelCacheAsset* Cache : ChannelCaches)
+        {
+            if (!bUseExplicitMapList || PackagedMaps.Contains(Cache->Level.GetLongPackageName()))
+                MapsToSave.Add(Cache);
+        }
+
+        if (bUseExplicitMapList)
+            UE_LOG(LogRenderStreamEditor, Log, TEXT("Saving %d of %d maps to the schema, filtered by the packaging settings map list."), MapsToSave.Num(), ChannelCaches.Num());
+
+        Schema.schema.scenes.nScenes = MapsToSave.Num();
         Schema.schema.scenes.scenes = static_cast<RenderStreamLink::RemoteParameters*>(malloc(Schema.schema.scenes.nScenes * sizeof(RenderStreamLink::RemoteParameters)));
         RenderStreamLink::RemoteParameters* SceneParameters = Schema.schema.scenes.scenes;
 
-        for (const URenderStreamChannelCacheAsset* Cache : ChannelCaches)
+        for (const URenderStreamChannelCacheAsset* Cache : MapsToSave)
         {
             const URenderStreamChannelCacheAsset** Entry = LevelParents.Find(Cache);
             GenerateScene(LevelParams, *SceneParameters++, Cache, Entry != nullptr ? *Entry : nullptr);

--- a/Source/RenderStreamEditor/RenderStreamEditor.Build.cs
+++ b/Source/RenderStreamEditor/RenderStreamEditor.Build.cs
@@ -13,10 +13,11 @@ public class RenderStreamEditor : ModuleRules
             "InputCore"
         });
         PrivateDependencyModuleNames.AddRange (new string[] { 
-            "CoreUObject", 
-            "Engine", 
-            "EngineSettings", 
-            "UnrealEd", 
+            "CoreUObject",
+            "Engine",
+            "EngineSettings",
+            "DeveloperToolSettings",
+            "UnrealEd",
             "RenderStream", 
             "DisplayCluster", 
             "Slate", 


### PR DESCRIPTION
See [RSP-409](https://d3technologies.atlassian.net/browse/RSP-409?atlOrigin=eyJpIjoiYTUzZGEyMzY1ODQ2NDM0NWE0Yjg0MzBlMzU1NGY4YmEiLCJwIjoiaiJ9)

The Sphere requested a way to only save a certain selection of maps to the schema since the current behaviour is to save all the ones in cache which is every map the plugin can find even if it's not being used. UE already provides a list in the settings for "List of maps to include in packaged build." 

<img width="1122" height="86" alt="image" src="https://github.com/user-attachments/assets/7812e8ed-ee81-4c60-999a-e790e69cc7d4" />

This feature just makes it so if that list is populated then we only save those ones to the schema, if it is not populated then it just results to the default behaviour.

[RSP-409]: https://d3technologies.atlassian.net/browse/RSP-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ