### PR TITLE
Access Violation When Stopping UE5.7 Workloads

### DIFF
--- a/Source/RenderStream/Private/RenderStream.cpp
+++ b/Source/RenderStream/Private/RenderStream.cpp
@@ -820,7 +820,7 @@ void FRenderStreamModule::OnBeginFrame()
     // The types are just random ones I picked
     // Epic is aware of this and is planning to fix it in 5.7.1
     ADisplayClusterRootActor* const RootActor = IDisplayCluster::Get().GetGameMgr()->GetRootActor();
-    if (RootActor->GetConfigData()->GetNode(ClusterMgr->GetNodeId())->MediaSettings.MediaOutputs.Num() == 0)
+    if (RootActor && RootActor->GetConfigData()->GetNode(ClusterMgr->GetNodeId())->MediaSettings.MediaOutputs.Num() == 0)
     {
         TObjectPtr<UFileMediaOutput> MediaOutput = NewObject<UFileMediaOutput>(GetTransientPackage());
         RootActor->GetConfigData()->GetNode(ClusterMgr->GetNodeId())->MediaSettings.bEnable = true;


### PR DESCRIPTION
See [RSP-406](https://d3technologies.atlassian.net/browse/RSP-406?atlOrigin=eyJpIjoiMjY5OGI3MmY1ZjUxNDQ0Y2FjNDgxNmE0ZjhlMjdjNzUiLCJwIjoiaiJ9)

When stopping 5.7 workloads there is an access violation that appears in the logs.

```
Unhandled Exception: EXCEPTION_ACCESS_VIOLATION reading address 0x00000000000004e8

0x00007ff8d7693e27 UnrealEditor-DisplayCluster.dll!UnknownFunction []
0x00007ff8d3f6ef20 UnrealEditor-RenderStream.dll!FRenderStreamModule::OnBeginFrame() [C:\unreal_plugin\disguiseuerenderstream\Packaged\RenderStream-UE\HostProject\Plugins\RenderStream-UE\Source\RenderStream\Private\RenderStream.cpp:818]
0x00007ff8d3f6a0b9 UnrealEditor-RenderStream.dll!TBaseRawMethodDelegateInstance<0,FRenderStreamModule,void __cdecl(void),FDefaultDelegateUserPolicy>::ExecuteIfSafe() [C:\link_to_unreal\UE_5.7\Engine\Source\Runtime\Core\Public\Delegates\DelegateInstancesImpl.h:566]
0x00007ff7bffd87c1 UnrealEditor.exe!UnknownFunction []
0x00007ff7bffc3cab UnrealEditor.exe!UnknownFunction []
0x00007ff7bffe0bfe UnrealEditor.exe!UnknownFunction []
0x00007ff7bffe0d0a UnrealEditor.exe!UnknownFunction []
0x00007ff7bffe4590 UnrealEditor.exe!UnknownFunction []
0x00007ff7bfff5be4 UnrealEditor.exe!UnknownFunction []
0x00007ff7bfff8f9a UnrealEditor.exe!UnknownFunction []
0x00007ff95cd87034 KERNEL32.DLL!UnknownFunction []
```
This is because when it does the workaround we get a pointer to the root actor which we then access methods from. There is no null check so when this logic is reached during shutdown it's after the root actor has already been deleted causing the access violation. This fix is only needed for 5.7 as it's the only version with this workaround.


[RSP-406]: https://d3technologies.atlassian.net/browse/RSP-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ