### PR TITLE
Fix UE failing to generate schema on "Save All"

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -94,6 +94,8 @@ void FRenderStreamEditorModule::StartupModule()
             this, &FRenderStreamEditorModule::RegisterSaveCommandOverrides));
     }
 
+    FEditorDelegates::PostSaveExternalActors.AddRaw(this, &FRenderStreamEditorModule::OnPostSaveWorld);
+    FEditorDelegates::PostSaveWorldWithContext.AddRaw(this, &FRenderStreamEditorModule::OnPostSaveWorldContext);
     FEditorDelegates::OnAssetsDeleted.AddRaw(this, &FRenderStreamEditorModule::OnAssetsDeleted);
     FCoreDelegates::OnBeginFrame.AddRaw(this, &FRenderStreamEditorModule::OnBeginFrame);
     FCoreDelegates::OnPostEngineInit.AddRaw(this, &FRenderStreamEditorModule::OnPostEngineInit);
@@ -118,6 +120,8 @@ void FRenderStreamEditorModule::ShutdownModule()
         PropertyModule.UnregisterCustomClassLayout("RenderStreamSettings");
     }
 
+    FEditorDelegates::PostSaveExternalActors.RemoveAll(this);
+    FEditorDelegates::PostSaveWorldWithContext.RemoveAll(this);
     FEditorDelegates::OnAssetsDeleted.RemoveAll(this);
     FCoreDelegates::OnBeginFrame.RemoveAll(this);
     FCoreDelegates::OnPostEngineInit.RemoveAll(this);
@@ -125,6 +129,8 @@ void FRenderStreamEditorModule::ShutdownModule()
     FEditorDelegates::OnShutdownPostPackagesSaved.RemoveAll(this);
     if (GEditor)
         GEditor->OnBlueprintCompiled().RemoveAll(this);
+
+    RestoreSaveCommandOverrides();
 
     UnregisterSettings();
 
@@ -1022,6 +1028,9 @@ void FRenderStreamEditorModule::RegisterSaveCommandOverrides()
         if (!ExistingAction)
             return;
 
+        // Keep the original so ShutdownModule can restore it; the global command list outlives this module.
+        OriginalSaveActions.Emplace(Command, *ExistingAction);
+
         // Copy the existing action so we preserve CanExecute/visibility, then chain schema regeneration
         FUIAction WrappedAction = *ExistingAction;
         const FExecuteAction OriginalExecute = WrappedAction.ExecuteAction;
@@ -1039,6 +1048,33 @@ void FRenderStreamEditorModule::RegisterSaveCommandOverrides()
 
     WrapSaveCommand(FLevelEditorCommands::Get().Save);
     WrapSaveCommand(FLevelEditorCommands::Get().SaveAllLevels);
+}
+
+void FRenderStreamEditorModule::RestoreSaveCommandOverrides()
+{
+    FLevelEditorModule* LevelEditorModule = FModuleManager::GetModulePtr<FLevelEditorModule>("LevelEditor");
+    if (LevelEditorModule)
+    {
+        const TSharedRef<FUICommandList> CommandList = LevelEditorModule->GetGlobalLevelEditorActions();
+        for (const TPair<TSharedPtr<FUICommandInfo>, FUIAction>& Original : OriginalSaveActions)
+        {
+            if (Original.Key.IsValid())
+                CommandList->MapAction(Original.Key, Original.Value);
+        }
+    }
+
+    OriginalSaveActions.Empty();
+}
+
+void FRenderStreamEditorModule::OnPostSaveWorldContext(UWorld* World, FObjectPostSaveContext Context)
+{
+    if (Context.SaveSucceeded())
+        DirtyAssetMetadata = true;
+}
+
+void FRenderStreamEditorModule::OnPostSaveWorld(UWorld* World)
+{
+    DirtyAssetMetadata = true;
 }
 
 void FRenderStreamEditorModule::OnAssetsDeleted(const TArray<UClass*>& DeletedAssetClasses)

--- a/Source/RenderStreamEditor/Public/RenderStreamEditorModule.h
+++ b/Source/RenderStreamEditor/Public/RenderStreamEditorModule.h
@@ -21,6 +21,7 @@ public:
     void RunPackageAndCopy();
     void RegisterToolBarButton();
     void RegisterSaveCommandOverrides();
+    void RestoreSaveCommandOverrides();
 
 private:
     FString StreamName();
@@ -30,6 +31,8 @@ private:
     // Delegates
     void OnBeginFrame();
     void OnAssetsDeleted(const TArray<UClass*>& DeletedAssetClasses);
+    void OnPostSaveWorld(UWorld* World);
+    void OnPostSaveWorldContext(UWorld* World, FObjectPostSaveContext Context);
 
     void OnPostEngineInit();
 
@@ -46,4 +49,6 @@ private:
 
     TWeakObjectPtr<UWorld> GameWorld;
     bool DirtyAssetMetadata = false;
+
+    TArray<TPair<TSharedPtr<FUICommandInfo>, FUIAction>> OriginalSaveActions;
 };


### PR DESCRIPTION
[RSP-411](https://d3technologies.atlassian.net/browse/RSP-411)

**Description:**
After [RSP-397](https://github.com/disguise-one/RenderStream-UE/pull/142) switched schema regeneration from save delegates to wrapping the `Save`/`SaveAllLevels` commands, the schema no longer regenerated for saves that don't go through those specific commands. Most visibly, using `Save All` after moving an object in a scene did nothing: the edit writes external-actor packages (not the level package), and that save path isn't one of the wrapped commands, so the schema went stale.

**Solution:**
- Restore the `PostSaveExternalActors` and `PostSaveWorldWithContext` editor delegates. These regenerate the schema whenever a save actually writes a world or external-actor package (Save All, content-browser saves, autosave, and OFPA actor edits). They complement the existing `Save`/`SaveAllLevels` command overrides, which still force a regenerate on an explicit save that writes nothing.
- Claude found another place for improvement: adding `RestoreSaveCommandOverrides()` call from `ShutdownModule`, to re-map the original command actions on module unload — so the global level-editor command list doesn't outlive the module holding a lambda that captures a freed module pointer.

**Note:**
Clicking `Save All` in UE only regenerates the schema after an object has been moved (different from `Save Current`). However, UE5.5 has exact same behaviour. RSP-397 was intended to match the behaviour between the 2.

[RSP-411]: https://d3technologies.atlassian.net/browse/RSP-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSP-397]: https://d3technologies.atlassian.net/browse/RSP-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ