### PR TITLE
Streaming Levels Refactor

### DIFF
--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -351,7 +351,7 @@ public:
         Scenes scenes;
         
         // Set to the persistent level's scene index in Streaming Levels mode; -1 for Maps/None.
-        int32_t baseSceneIndex;
+        int32_t defaultSceneIndex;
     } Schema;
 
     typedef struct
@@ -531,7 +531,7 @@ public:
             schema.channels.channels = nullptr;
             schema.scenes.nScenes = 0;
             schema.scenes.scenes = nullptr;
-            schema.baseSceneIndex = -1;
+            schema.defaultSceneIndex = -1;
         }
         ScopedSchema(const ScopedSchema&) = delete;
         ScopedSchema(ScopedSchema&& other)

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -349,6 +349,9 @@ public:
         RSColourSpace workingColourSpace;
         Channels channels;
         Scenes scenes;
+        
+        // Set to the persistent level's scene index in Streaming Levels mode; -1 for Maps/None.
+        int32_t baseSceneIndex;
     } Schema;
 
     typedef struct
@@ -528,6 +531,7 @@ public:
             schema.channels.channels = nullptr;
             schema.scenes.nScenes = 0;
             schema.scenes.scenes = nullptr;
+            schema.baseSceneIndex = -1;
         }
         ScopedSchema(const ScopedSchema&) = delete;
         ScopedSchema(ScopedSchema&& other)

--- a/Source/RenderStream/Public/RenderStreamLink.h
+++ b/Source/RenderStream/Public/RenderStreamLink.h
@@ -367,7 +367,7 @@ public:
 
 #define MIN_D3_VERSION_MAJOR 34
 #define MIN_D3_VERSION_MINOR 0
-#define MIN_D3_VERSION_PATCH 0
+#define MIN_D3_VERSION_PATCH 2
 
     enum UseDX12SharedHeapFlag
     {

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -472,8 +472,7 @@ void FetchLevelCaches(
 void GenerateScene(
     TMap<FSoftObjectPath, URenderStreamChannelCacheAsset*> const& LevelParams,
     RenderStreamLink::RemoteParameters& SceneParameters,
-    const URenderStreamChannelCacheAsset* Cache,
-    const URenderStreamChannelCacheAsset* Persistent)
+    const URenderStreamChannelCacheAsset* Cache)
 {
     FString sceneName = Cache->GetName();
     SceneParameters.name = _strdup(TCHAR_TO_UTF8(*sceneName));
@@ -858,7 +857,7 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
             Schema.schema.scenes.scenes = static_cast<RenderStreamLink::RemoteParameters*>(
                 malloc(Schema.schema.scenes.nScenes * sizeof(RenderStreamLink::RemoteParameters)));
             RenderStreamLink::RemoteParameters* SceneParameters = Schema.schema.scenes.scenes;
-            GenerateScene(LevelParams, *SceneParameters++, MainMap, nullptr);
+            GenerateScene(LevelParams, *SceneParameters++, MainMap);
         }
         else
         {
@@ -879,12 +878,12 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
                 malloc(Schema.schema.scenes.nScenes * sizeof(RenderStreamLink::RemoteParameters)));
             RenderStreamLink::RemoteParameters* SceneParameters = Schema.schema.scenes.scenes;
 
-            GenerateScene(LevelParams, *SceneParameters++, MainMap, nullptr);
+            GenerateScene(LevelParams, *SceneParameters++, MainMap);
             for (FSoftObjectPath Path : MainMap->SubLevels)
             {
                 URenderStreamChannelCacheAsset** Cache = LevelParams.Find(Path);
                 if (Cache != nullptr)
-                    GenerateScene(LevelParams, *SceneParameters++, *Cache, MainMap);
+                    GenerateScene(LevelParams, *SceneParameters++, *Cache);
             }
 
             // Scene 0 is the persistent level
@@ -901,17 +900,6 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
 
     case ERenderStreamSceneSelector::Maps:
     {
-        TMap<const URenderStreamChannelCacheAsset*, const URenderStreamChannelCacheAsset*> LevelParents;
-        for (const URenderStreamChannelCacheAsset* Cache : ChannelCaches)
-        {
-            for (FSoftObjectPath Path : Cache->SubLevels)
-            {
-                URenderStreamChannelCacheAsset** Parent = LevelParams.Find(Path);
-                if (Parent != nullptr)
-                    LevelParents.Add(*Parent, Cache);
-            }
-        }
-
         // If the project's packaging settings specify an explicit list of maps to include in the
         // packaged build, only save those maps to the schema. Otherwise save every map we cached.
         const UProjectPackagingSettings* PackagingSettings = GetDefault<UProjectPackagingSettings>();
@@ -940,8 +928,7 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
 
         for (const URenderStreamChannelCacheAsset* Cache : MapsToSave)
         {
-            const URenderStreamChannelCacheAsset** Entry = LevelParents.Find(Cache);
-            GenerateScene(LevelParams, *SceneParameters++, Cache, Entry != nullptr ? *Entry : nullptr);
+            GenerateScene(LevelParams, *SceneParameters++, Cache);
         }
 
         break;

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -479,11 +479,8 @@ void GenerateScene(
     SceneParameters.name = _strdup(TCHAR_TO_UTF8(*sceneName));
 
     const URenderStreamSettings* settings = GetDefault<URenderStreamSettings>();
-    bool isStreamingLevelSceneSelector = settings->SceneSelector == ERenderStreamSceneSelector::StreamingLevels;
 
     TArray<const URenderStreamChannelCacheAsset*> Levels;
-    if (Persistent && isStreamingLevelSceneSelector) // add persistent level's parameters to sublevels for Streaming level only
-        Levels.Push(Persistent);
 
     bool needToFetchSublevels = settings->SceneSelector == ERenderStreamSceneSelector::None;
     FetchLevelCaches(LevelParams, Levels, Cache, needToFetchSublevels);
@@ -889,6 +886,9 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
                 if (Cache != nullptr)
                     GenerateScene(LevelParams, *SceneParameters++, *Cache, MainMap);
             }
+
+            // Scene 0 is the persistent level
+            Schema.schema.baseSceneIndex = 0;
         }
         else
         {

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -887,7 +887,7 @@ void FRenderStreamEditorModule::GenerateAssetMetadata()
             }
 
             // Scene 0 is the persistent level
-            Schema.schema.baseSceneIndex = 0;
+            Schema.schema.defaultSceneIndex = 0;
         }
         else
         {


### PR DESCRIPTION
See [RSP-410](https://d3technologies.atlassian.net/browse/RSP-410?atlOrigin=eyJpIjoiMzI4OTU5YmZjYTcyNDBjZGEwNGEwZGZiYjdiZjM5OWYiLCJwIjoiaiJ9)

When working with many sublevels it can take awhile to save the schema since every exposed parameter in the persistent level is duplicated to every sublevel. This can cause friction when working in large projects and is an issue highlighted by the Sphere. The plugin side fixes are simple as we simply just don't save the persistent parameters to sublevel sections. A new schema field has been added so d3 can tell if the workload is using streaming levels or not. This also points to the scene index that it needs to pull from (for now it's always 0).

For the d3 changes see this [PR](https://github.com/disguise-one/d3/pull/7243)

[RSP-410]: https://d3technologies.atlassian.net/browse/RSP-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ