### PR TITLE
Packaging UE Builds With Shipping Config

### DIFF
--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -948,8 +948,33 @@ struct FRequiredEngineSetting
     const TCHAR* Value;
 };
 
+bool IniSectionContainsSetting(const FString& IniContents, const FRequiredEngineSetting& Setting)
+{
+    const FString sectionHeader = FString::Printf(TEXT("[%s]"), Setting.Section);
+    const FString entry = FString::Printf(TEXT("%s=%s"), Setting.Key, Setting.Value);
+
+    TArray<FString> lines;
+    IniContents.ParseIntoArrayLines(lines);
+
+    bool inSection = false;
+    for (const FString& line : lines)
+    {
+        const FString trimmed = line.TrimStartAndEnd();
+
+        if (trimmed.StartsWith(TEXT(";")) || trimmed.StartsWith(TEXT("#")))
+            continue;
+
+        if (trimmed.StartsWith(TEXT("[")))
+            inSection = trimmed.Equals(sectionHeader, ESearchCase::IgnoreCase);
+        else if (inSection && trimmed.Equals(entry, ESearchCase::IgnoreCase))
+            return true;
+    }
+
+    return false;
+}
+
 // When laucnhing d3 tries to modifiy the ini files, however in shipping builds ini files are unable to be overwritten
-void EnsureShippingLaunchConfig()
+bool EnsureShippingLaunchConfig()
 {
     static const FRequiredEngineSetting RequiredSettings[] = {
         { TEXT("/Script/Engine.Engine"), TEXT("GameEngine"), TEXT("/Script/DisplayCluster.DisplayClusterGameEngine") },
@@ -967,7 +992,7 @@ void EnsureShippingLaunchConfig()
     for (const FRequiredEngineSetting& setting : RequiredSettings)
     {
         const FString entry = FString::Printf(TEXT("%s=%s"), setting.Key, setting.Value);
-        if (iniContents.Contains(entry))
+        if (IniSectionContainsSetting(iniContents, setting))
             continue;
 
         if (currentSection != setting.Section)
@@ -981,7 +1006,7 @@ void EnsureShippingLaunchConfig()
     }
 
     if (additions.IsEmpty())
-        return;
+        return true;
 
     // In case ini is already checked in
     if (SourceControlHelpers::IsEnabled() && FPaths::FileExists(engineIniPath))
@@ -992,7 +1017,12 @@ void EnsureShippingLaunchConfig()
     }
 
     if (!FFileHelper::SaveStringToFile(additions, *engineIniPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM, &IFileManager::Get(), FILEWRITE_Append))
+    {
         UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to write %s"), *engineIniPath);
+        return false;
+    }
+
+    return true;
 }
 
 void FRenderStreamEditorModule::RunPackageAndCopy()
@@ -1007,7 +1037,11 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
     if(outputFolder == FString())
         return;
 
-    EnsureShippingLaunchConfig();
+    if (!EnsureShippingLaunchConfig())
+    {
+        UE_LOG(LogRenderStreamEditor, Error, TEXT("Aborting packaging, the required launch settings could not be written."));
+        return;
+    }
 
     FString arguments = FString::Printf(TEXT("Turnkey -command=VerifySdk -platform=Win64 -UpdateIfNeeded \
         BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -project=\"%s\" -target=%s -unrealexe=\"%s\" \
@@ -1024,7 +1058,7 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
     bool bSuccess = FPlatformProcess::ExecProcess(*uatPath, *arguments, &ReturnCode, &errorOut, nullptr);
     UE_LOG(LogTemp, Log, TEXT("Packaging complete..."));
 
-    if (bSuccess)
+    if (bSuccess && ReturnCode == 0)
     {
         // Need to copy metadata over to new .exe location
         FString filename = FString::Printf(TEXT("rs_%s.json"), FApp::GetProjectName());
@@ -1049,26 +1083,25 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
         const FString binariesDir = outputFolder / FString::Printf(TEXT("Windows/%s/Binaries/Win64"), *projectName);
         const FString undecoratedExe = binariesDir / FString::Printf(TEXT("%s.exe"), *projectName);
 
-        TArray<FString> decoratedExes;
-        IFileManager::Get().FindFiles(decoratedExes, *(binariesDir / TEXT("*-Win64-Shipping.exe")), true, false);
-
-        if (decoratedExes.Num() > 1)
-            UE_LOG(LogRenderStreamEditor, Warning, TEXT("Found %d Shipping executables in %s, renaming the first only."), decoratedExes.Num(), *binariesDir);
-
-        if (decoratedExes.Num() > 0)
+        const FString decoratedExe = binariesDir / FString::Printf(TEXT("%s-Win64-Shipping.exe"), *projectName);
+        if (FPaths::FileExists(decoratedExe))
         {
-            const FString decoratedExe = binariesDir / decoratedExes[0];
-
             if (FPaths::FileExists(undecoratedExe))
-                IFileManager::Get().Delete(*undecoratedExe);
+                UE_LOG(LogRenderStreamEditor, Log, TEXT("Replacing existing %s"), *undecoratedExe);
 
-            if (!IFileManager::Get().Move(*undecoratedExe, *decoratedExe))
+            if (IFileManager::Get().Move(*undecoratedExe, *decoratedExe))
+                UE_LOG(LogRenderStreamEditor, Log, TEXT("Renamed %s to %s"), *decoratedExe, *undecoratedExe);
+            else
                 UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to rename %s to %s"), *decoratedExe, *undecoratedExe);
+        }
+        else if (!FPaths::FileExists(undecoratedExe))
+        {
+            UE_LOG(LogRenderStreamEditor, Error, TEXT("Neither %s nor %s was found, d3 will not be able to launch this build."), *decoratedExe, *undecoratedExe);
         }
     }
     else
     {
-        UE_LOG(LogTemp, Error, TEXT("UAT proccess failed with error code: %s"), *errorOut);
+        UE_LOG(LogTemp, Error, TEXT("UAT proccess failed with return code %d: %s"), ReturnCode, *errorOut);
     }
 }
 

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -48,6 +48,7 @@
 
 #include "DesktopPlatformModule.h"
 #include "IDesktopPlatform.h"
+#include "Misc/FileHelper.h"
 
 DEFINE_LOG_CATEGORY(LogRenderStreamEditor);
 
@@ -940,6 +941,52 @@ FString FRenderStreamEditorModule::GetSelectedOutputFolder()
     return FString();
 }
 
+struct FRequiredEngineSetting
+{
+    const TCHAR* Section;
+    const TCHAR* Key;
+    const TCHAR* Value;
+};
+
+// When laucnhing d3 tries to modifiy the ini files, however in shipping builds ini files are unable to be overwritten
+void EnsureShippingLaunchConfig()
+{
+    static const FRequiredEngineSetting RequiredSettings[] = {
+        { TEXT("/Script/Engine.Engine"), TEXT("GameEngine"), TEXT("/Script/DisplayCluster.DisplayClusterGameEngine") },
+        { TEXT("/Script/Engine.Engine"), TEXT("GameViewportClientClassName"), TEXT("/Script/RenderStream.RenderStreamViewportClient") },
+        { TEXT("SystemSettings"), TEXT("rhi.UseSubmissionThread"), TEXT("0") },
+    };
+
+    const FString engineIniPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir() / TEXT("DefaultEngine.ini"));
+
+    FString iniContents;
+    FFileHelper::LoadFileToString(iniContents, *engineIniPath);
+
+    FString additions;
+    FString currentSection;
+    for (const FRequiredEngineSetting& setting : RequiredSettings)
+    {
+        const FString entry = FString::Printf(TEXT("%s=%s"), setting.Key, setting.Value);
+        if (iniContents.Contains(entry))
+            continue;
+
+        if (currentSection != setting.Section)
+        {
+            currentSection = setting.Section;
+            additions += FString::Printf(TEXT("%s[%s]%s"), LINE_TERMINATOR, setting.Section, LINE_TERMINATOR);
+        }
+
+        additions += entry + LINE_TERMINATOR;
+        UE_LOG(LogRenderStreamEditor, Log, TEXT("Adding [%s] %s to %s"), setting.Section, *entry, *engineIniPath);
+    }
+
+    if (additions.IsEmpty())
+        return;
+
+    if (!FFileHelper::SaveStringToFile(additions, *engineIniPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM, &IFileManager::Get(), FILEWRITE_Append))
+        UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to write %s"), *engineIniPath);
+}
+
 void FRenderStreamEditorModule::RunPackageAndCopy()
 {
     FString uatPath = FPaths::ConvertRelativePathToFull(FPaths::EngineDir() / TEXT("Build/BatchFiles/RunUAT.bat"));
@@ -952,10 +999,12 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
     if(outputFolder == FString())
         return;
 
+    EnsureShippingLaunchConfig();
+
     FString arguments = FString::Printf(TEXT("Turnkey -command=VerifySdk -platform=Win64 -UpdateIfNeeded \
         BuildCookRun -nop4 -utf8output -nocompileeditor -skipbuildeditor -cook -project=\"%s\" -target=%s -unrealexe=\"%s\" \
         -platform=Win64 -installed -stage -archive -package -build -pak -iostore -compressed -prereqs \
-        -archivedirectory=\"%s\" -clientconfig=Development -nocompile -nocompileuat"),
+        -archivedirectory=\"%s\" -clientconfig=Shipping -nocompile -nocompileuat -NoBootstrapExe"),
         *projectPath,
         *projectName,
         *enginePath,
@@ -986,6 +1035,27 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
         if (!copySuccess)
         {
             UE_LOG(LogTemp, Log, TEXT("Failed to copy the meatadata over!"));
+        }
+
+        // UAT adds a suffux to shipping builds that needs to be removed to match the json name
+        const FString binariesDir = outputFolder / FString::Printf(TEXT("Windows/%s/Binaries/Win64"), *projectName);
+        const FString undecoratedExe = binariesDir / FString::Printf(TEXT("%s.exe"), *projectName);
+
+        TArray<FString> decoratedExes;
+        IFileManager::Get().FindFiles(decoratedExes, *(binariesDir / TEXT("*-Win64-Shipping.exe")), true, false);
+
+        if (decoratedExes.Num() > 1)
+            UE_LOG(LogRenderStreamEditor, Warning, TEXT("Found %d Shipping executables in %s, renaming the first only."), decoratedExes.Num(), *binariesDir);
+
+        if (decoratedExes.Num() > 0)
+        {
+            const FString decoratedExe = binariesDir / decoratedExes[0];
+
+            if (FPaths::FileExists(undecoratedExe))
+                IFileManager::Get().Delete(*undecoratedExe);
+
+            if (!IFileManager::Get().Move(*undecoratedExe, *decoratedExe))
+                UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to rename %s to %s"), *decoratedExe, *undecoratedExe);
         }
     }
     else

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -941,88 +941,91 @@ FString FRenderStreamEditorModule::GetSelectedOutputFolder()
     return FString();
 }
 
-struct FRequiredEngineSetting
+namespace RenderStreamPackaging
 {
-    const TCHAR* Section;
-    const TCHAR* Key;
-    const TCHAR* Value;
-};
-
-bool IniSectionContainsSetting(const FString& IniContents, const FRequiredEngineSetting& Setting)
-{
-    const FString sectionHeader = FString::Printf(TEXT("[%s]"), Setting.Section);
-    const FString entry = FString::Printf(TEXT("%s=%s"), Setting.Key, Setting.Value);
-
-    TArray<FString> lines;
-    IniContents.ParseIntoArrayLines(lines);
-
-    bool inSection = false;
-    for (const FString& line : lines)
+    struct FRequiredEngineSetting
     {
-        const FString trimmed = line.TrimStartAndEnd();
-
-        if (trimmed.StartsWith(TEXT(";")) || trimmed.StartsWith(TEXT("#")))
-            continue;
-
-        if (trimmed.StartsWith(TEXT("[")))
-            inSection = trimmed.Equals(sectionHeader, ESearchCase::IgnoreCase);
-        else if (inSection && trimmed.Equals(entry, ESearchCase::IgnoreCase))
-            return true;
-    }
-
-    return false;
-}
-
-// When laucnhing d3 tries to modifiy the ini files, however in shipping builds ini files are unable to be overwritten
-bool EnsureShippingLaunchConfig()
-{
-    static const FRequiredEngineSetting RequiredSettings[] = {
-        { TEXT("/Script/Engine.Engine"), TEXT("GameEngine"), TEXT("/Script/DisplayCluster.DisplayClusterGameEngine") },
-        { TEXT("/Script/Engine.Engine"), TEXT("GameViewportClientClassName"), TEXT("/Script/RenderStream.RenderStreamViewportClient") },
-        { TEXT("SystemSettings"), TEXT("rhi.UseSubmissionThread"), TEXT("0") },
+        const TCHAR* Section;
+        const TCHAR* Key;
+        const TCHAR* Value;
     };
 
-    const FString engineIniPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir() / TEXT("DefaultEngine.ini"));
-
-    FString iniContents;
-    FFileHelper::LoadFileToString(iniContents, *engineIniPath);
-
-    FString additions;
-    FString currentSection;
-    for (const FRequiredEngineSetting& setting : RequiredSettings)
+    bool IniSectionContainsSetting(const FString& IniContents, const FRequiredEngineSetting& Setting)
     {
-        const FString entry = FString::Printf(TEXT("%s=%s"), setting.Key, setting.Value);
-        if (IniSectionContainsSetting(iniContents, setting))
-            continue;
+        const FString sectionHeader = FString::Printf(TEXT("[%s]"), Setting.Section);
+        const FString entry = FString::Printf(TEXT("%s=%s"), Setting.Key, Setting.Value);
 
-        if (currentSection != setting.Section)
+        TArray<FString> lines;
+        IniContents.ParseIntoArrayLines(lines);
+
+        bool inSection = false;
+        for (const FString& line : lines)
         {
-            currentSection = setting.Section;
-            additions += FString::Printf(TEXT("%s[%s]%s"), LINE_TERMINATOR, setting.Section, LINE_TERMINATOR);
+            const FString trimmed = line.TrimStartAndEnd();
+
+            if (trimmed.StartsWith(TEXT(";")) || trimmed.StartsWith(TEXT("#")))
+                continue;
+
+            if (trimmed.StartsWith(TEXT("[")))
+                inSection = trimmed.Equals(sectionHeader, ESearchCase::IgnoreCase);
+            else if (inSection && trimmed.Equals(entry, ESearchCase::IgnoreCase))
+                return true;
         }
 
-        additions += entry + LINE_TERMINATOR;
-        UE_LOG(LogRenderStreamEditor, Log, TEXT("Adding [%s] %s to %s"), setting.Section, *entry, *engineIniPath);
-    }
-
-    if (additions.IsEmpty())
-        return true;
-
-    // In case ini is already checked in
-    if (SourceControlHelpers::IsEnabled() && FPaths::FileExists(engineIniPath))
-    {
-        const FSourceControlState iniSCState = SourceControlHelpers::QueryFileState(engineIniPath);
-        if (iniSCState.bIsSourceControlled && !iniSCState.bIsCheckedOut && !SourceControlHelpers::CheckOutFile(engineIniPath))
-            UE_LOG(LogRenderStreamEditor, Error, TEXT("%s failed to check out."), *engineIniPath);
-    }
-
-    if (!FFileHelper::SaveStringToFile(additions, *engineIniPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM, &IFileManager::Get(), FILEWRITE_Append))
-    {
-        UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to write %s"), *engineIniPath);
         return false;
     }
 
-    return true;
+    // When laucnhing d3 tries to modifiy the ini files, however in shipping builds ini files are unable to be overwritten
+    bool EnsureShippingLaunchConfig()
+    {
+        static const FRequiredEngineSetting RequiredSettings[] = {
+            { TEXT("/Script/Engine.Engine"), TEXT("GameEngine"), TEXT("/Script/DisplayCluster.DisplayClusterGameEngine") },
+            { TEXT("/Script/Engine.Engine"), TEXT("GameViewportClientClassName"), TEXT("/Script/RenderStream.RenderStreamViewportClient") },
+            { TEXT("SystemSettings"), TEXT("rhi.UseSubmissionThread"), TEXT("0") },
+        };
+
+        const FString engineIniPath = FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir() / TEXT("DefaultEngine.ini"));
+
+        FString iniContents;
+        FFileHelper::LoadFileToString(iniContents, *engineIniPath);
+
+        FString additions;
+        FString currentSection;
+        for (const FRequiredEngineSetting& setting : RequiredSettings)
+        {
+            const FString entry = FString::Printf(TEXT("%s=%s"), setting.Key, setting.Value);
+            if (IniSectionContainsSetting(iniContents, setting))
+                continue;
+
+            if (currentSection != setting.Section)
+            {
+                currentSection = setting.Section;
+                additions += FString::Printf(TEXT("%s[%s]%s"), LINE_TERMINATOR, setting.Section, LINE_TERMINATOR);
+            }
+
+            additions += entry + LINE_TERMINATOR;
+            UE_LOG(LogRenderStreamEditor, Log, TEXT("Adding [%s] %s to %s"), setting.Section, *entry, *engineIniPath);
+        }
+
+        if (additions.IsEmpty())
+            return true;
+
+        // In case ini is already checked in
+        if (SourceControlHelpers::IsEnabled() && FPaths::FileExists(engineIniPath))
+        {
+            const FSourceControlState iniSCState = SourceControlHelpers::QueryFileState(engineIniPath);
+            if (iniSCState.bIsSourceControlled && !iniSCState.bIsCheckedOut && !SourceControlHelpers::CheckOutFile(engineIniPath))
+                UE_LOG(LogRenderStreamEditor, Error, TEXT("%s failed to check out."), *engineIniPath);
+        }
+
+        if (!FFileHelper::SaveStringToFile(additions, *engineIniPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM, &IFileManager::Get(), FILEWRITE_Append))
+        {
+            UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to write %s"), *engineIniPath);
+            return false;
+        }
+
+        return true;
+    }
 }
 
 void FRenderStreamEditorModule::RunPackageAndCopy()
@@ -1037,7 +1040,7 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
     if(outputFolder == FString())
         return;
 
-    if (!EnsureShippingLaunchConfig())
+    if (!RenderStreamPackaging::EnsureShippingLaunchConfig())
     {
         UE_LOG(LogRenderStreamEditor, Error, TEXT("Aborting packaging, the required launch settings could not be written."));
         return;
@@ -1090,9 +1093,17 @@ void FRenderStreamEditorModule::RunPackageAndCopy()
                 UE_LOG(LogRenderStreamEditor, Log, TEXT("Replacing existing %s"), *undecoratedExe);
 
             if (IFileManager::Get().Move(*undecoratedExe, *decoratedExe))
+            {
                 UE_LOG(LogRenderStreamEditor, Log, TEXT("Renamed %s to %s"), *decoratedExe, *undecoratedExe);
+            }
             else
+            {
                 UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to rename %s to %s"), *decoratedExe, *undecoratedExe);
+
+                // Delete old exe
+                if (FPaths::FileExists(undecoratedExe) && !IFileManager::Get().Delete(*undecoratedExe))
+                    UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to delete stale %s"), *undecoratedExe);
+            }
         }
         else if (!FPaths::FileExists(undecoratedExe))
         {

--- a/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
+++ b/Source/RenderStreamEditor/Private/RenderStreamEditorModule.cpp
@@ -983,6 +983,14 @@ void EnsureShippingLaunchConfig()
     if (additions.IsEmpty())
         return;
 
+    // In case ini is already checked in
+    if (SourceControlHelpers::IsEnabled() && FPaths::FileExists(engineIniPath))
+    {
+        const FSourceControlState iniSCState = SourceControlHelpers::QueryFileState(engineIniPath);
+        if (iniSCState.bIsSourceControlled && !iniSCState.bIsCheckedOut && !SourceControlHelpers::CheckOutFile(engineIniPath))
+            UE_LOG(LogRenderStreamEditor, Error, TEXT("%s failed to check out."), *engineIniPath);
+    }
+
     if (!FFileHelper::SaveStringToFile(additions, *engineIniPath, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM, &IFileManager::Get(), FILEWRITE_Append))
         UE_LOG(LogRenderStreamEditor, Error, TEXT("Failed to write %s"), *engineIniPath);
 }


### PR DESCRIPTION
See [RSP-412](https://d3technologies.atlassian.net/browse/RSP-412?atlOrigin=eyJpIjoiYzk5YTI4ZmZkZGJiNDI4MTk1NTVkOTM4NDZmYzlkMjgiLCJwIjoiaiJ9)

There were 2 issues with packaging that the Sphere wanted resolved. One issue is that when packaging, by default UAT will produce 2 exes with the same name. One of these is the actually exe and one is a launcher known as the bootstrap exe. The solution is to use the -NoBootstrapExe flag to prevent this.

The second issue is that builds were being defaulted to the Development config. This is also a straightforward change but it produces consequences that need to be fixed as well. The first of these is that the resulting name that is given is appended with -win64-shipping. This is a problem since d3 expects the name of the exe to be the same as the json schema file name. The solution here is to just rename the exe after packaging to strip the end. The second consequence is that when in shipping mode UE blocks the ability to overwrite DefaultEngine.ini. This is a problem because on launch d3 will try to overwrite that file will specific entries needed for nDisplay to work correctly. The solution is to overwrite those files before the packaging is done.

[RSP-412]: https://d3technologies.atlassian.net/browse/RSP-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Packaging now produces Shipping builds with prerequisite and bootstrap settings.
  * Missing engine and system configuration is added automatically.
  * Packaged executables are renamed to the project’s standard name, with metadata copied alongside them.

* **Bug Fixes**
  * Packaging post-processing now proceeds only after a successful build.
  * Existing target executables are replaced, and failures during renaming are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->